### PR TITLE
feat(bullet): 分波次弹幕系统（WaveDirector + 可配置弹幕群）

### DIFF
--- a/ability/event_bus.gd
+++ b/ability/event_bus.gd
@@ -24,6 +24,14 @@ signal on_synergy_activated(synergy_id: String)
 ## 反击螺旋触发
 signal on_counter_spiral_trigger(context: Dictionary)
 
+# ---------- 弹幕波次事件 ----------
+## 进入波次准备阶段：context 包含 wave_id, index, loop, prep_time, duration, pattern_id
+signal on_wave_prep_started(context: Dictionary)
+## 波次正式开始发射：context 包含 wave_id, index, loop, duration, fire_interval, bullet_speed, pattern_id
+signal on_wave_started(context: Dictionary)
+## 波次结束：context 包含 wave_id, index, loop
+signal on_wave_ended(context: Dictionary)
+
 
 # --- 便捷封装：发射格挡事件并返回上下文 ---
 func emit_block(player: Node, blocked_body: Node, extra: Dictionary = {}) -> Dictionary:

--- a/bullet/bullet.gd
+++ b/bullet/bullet.gd
@@ -9,9 +9,15 @@ var direction: Vector2 = Vector2.ZERO
 func _ready() -> void:
 	visible_notifier.screen_exited.connect(_on_screen_exited)
 
-func init(target_position: Vector2) -> void:
-	direction = (target_position - global_position).normalized()
+# 由 BulletSpawner 调用：spawn_pos 是出生点，dir 是单位方向向量，bullet_speed 覆盖默认速度。
+func init(spawn_pos: Vector2, dir: Vector2, bullet_speed: float = -1.0) -> void:
+	global_position = spawn_pos
+	if dir.length_squared() <= 0.0:
+		dir = Vector2.DOWN
+	direction = dir.normalized()
 	rotation = direction.angle()
+	if bullet_speed > 0.0:
+		speed = bullet_speed
 
 func _physics_process(delta: float) -> void:
 	var collision = move_and_collide(direction * speed * delta)

--- a/bullet/bullet_spawner.gd
+++ b/bullet/bullet_spawner.gd
@@ -1,58 +1,183 @@
 extends Node
 
+# 弹幕生成器：被动式 API，由 WaveDirector 调用 fire_pattern() 按弹幕群配置发射子弹。
+# 不再持有自己的发射节奏，所有时间参数由 WaveDirector 决定。
+
 @export var bullet_scene: PackedScene
-@export var spawn_interval: float = 1.0
-@export var initial_delay: float = 2.0
 
 const SCREEN_WIDTH: float = 640.0
 const SCREEN_HEIGHT: float = 960.0
+const SCREEN_CENTER: Vector2 = Vector2(SCREEN_WIDTH * 0.5, SCREEN_HEIGHT * 0.5)
 const SPAWN_MARGIN: float = 50.0
 
 var player: CharacterBody2D
-var spawning: bool = true
+var _bullet_counter: int = 0
+var _inflight_token: int = 0
+
 
 func _ready() -> void:
-	player = get_node("../player")
-	await get_tree().create_timer(initial_delay, false).timeout
-	_start_spawning()
+	player = get_node_or_null("../player")
+	if player == null:
+		push_warning("[BulletSpawner] 未找到 player 节点，将无法瞄准玩家")
 
-func _start_spawning() -> void:
-	while spawning:
-		_spawn_bullet()
-		await get_tree().create_timer(spawn_interval, false).timeout
 
-var bullet_counter: int = 0
+# === 公共 API ==================================================================
 
-func _spawn_bullet() -> void:
+# 立即按 pattern 配置发射一组子弹。line_burst 等需要分帧的 pattern 会启动协程。
+func fire_pattern(pattern_def: Dictionary, bullet_speed: float) -> void:
+	if pattern_def.is_empty():
+		return
 	if not is_instance_valid(player):
 		return
-	
-	bullet_counter += 1
-	var bullet = bullet_scene.instantiate()
-	bullet.name = "bullet_" + str(bullet_counter)
-	bullet.global_position = _get_random_spawn_position()
-	bullet.init(player.global_position)
-	get_parent().add_child(bullet)
+	var shape: String = String(pattern_def.get("shape", "single"))
+	match shape:
+		"single":
+			_fire_single(pattern_def, bullet_speed)
+		"fan":
+			_fire_fan(pattern_def, bullet_speed)
+		"ring":
+			_fire_ring(pattern_def, bullet_speed)
+		"line_burst":
+			_fire_line_burst(pattern_def, bullet_speed)
+		_:
+			push_warning("[BulletSpawner] 未知 shape: %s" % shape)
 
-func _get_random_spawn_position() -> Vector2:
-	var edge = randi() % 4
-	var pos = Vector2.ZERO
-	
+
+# 切换波次时调用：取消进行中的连射，避免上一波的 burst 溢出到新波次。
+func cancel_inflight() -> void:
+	_inflight_token += 1
+
+
+# === 形状实现 ==================================================================
+
+func _fire_single(pattern_def: Dictionary, bullet_speed: float) -> void:
+	var origin: Vector2 = _resolve_spawn(pattern_def)
+	var direction: Vector2 = _resolve_direction(pattern_def, origin)
+	_spawn_one(origin, direction, bullet_speed)
+
+
+func _fire_fan(pattern_def: Dictionary, bullet_speed: float) -> void:
+	var count: int = maxi(1, int(pattern_def.get("count", 1)))
+	var spread_deg: float = float(pattern_def.get("spread_deg", 0.0))
+	var origin: Vector2 = _resolve_spawn(pattern_def)
+	var base_dir: Vector2 = _resolve_direction(pattern_def, origin)
+	if base_dir == Vector2.ZERO:
+		base_dir = Vector2.DOWN
+	var spread_rad: float = deg_to_rad(spread_deg)
+	for i in range(count):
+		var t: float = 0.0 if count == 1 else float(i) / float(count - 1)
+		var angle: float = -spread_rad * 0.5 + t * spread_rad
+		var dir: Vector2 = base_dir.rotated(angle)
+		_spawn_one(origin, dir, bullet_speed)
+
+
+func _fire_ring(pattern_def: Dictionary, bullet_speed: float) -> void:
+	var count: int = maxi(1, int(pattern_def.get("count", 1)))
+	var rotation_offset_deg: float = float(pattern_def.get("rotation_offset_deg", 0.0))
+	var spawn_distance: float = float(pattern_def.get("spawn_distance", 0.0))
+	var center: Vector2 = _resolve_spawn(pattern_def)
+	var aim: String = String(pattern_def.get("aim", "outward"))
+	var rotation_offset: float = deg_to_rad(rotation_offset_deg)
+	for i in range(count):
+		var angle: float = TAU * float(i) / float(count) + rotation_offset
+		var radial: Vector2 = Vector2.RIGHT.rotated(angle)
+		var origin: Vector2 = center + radial * spawn_distance
+		var dir: Vector2 = radial
+		if aim == "player" and is_instance_valid(player):
+			dir = (player.global_position - origin).normalized()
+		_spawn_one(origin, dir, bullet_speed)
+
+
+func _fire_line_burst(pattern_def: Dictionary, bullet_speed: float) -> void:
+	_run_line_burst(pattern_def, bullet_speed, _inflight_token)
+
+
+func _run_line_burst(pattern_def: Dictionary, bullet_speed: float, token: int) -> void:
+	var count: int = maxi(1, int(pattern_def.get("count", 1)))
+	var interval: float = maxf(0.0, float(pattern_def.get("interval", 0.1)))
+	for i in range(count):
+		if token != _inflight_token:
+			return
+		if not is_instance_valid(player):
+			return
+		var origin: Vector2 = _resolve_spawn(pattern_def)
+		var direction: Vector2 = _resolve_direction(pattern_def, origin)
+		_spawn_one(origin, direction, bullet_speed)
+		if i == count - 1 or interval <= 0.0:
+			break
+		await get_tree().create_timer(interval, false).timeout
+
+
+# === 解析 spawn / aim ==========================================================
+
+func _resolve_spawn(pattern_def: Dictionary) -> Vector2:
+	var mode: String = String(pattern_def.get("spawn", "edge_random"))
+	match mode:
+		"edge_random":
+			return _edge_random_position()
+		"near_player":
+			if is_instance_valid(player):
+				return player.global_position
+			return SCREEN_CENTER
+		"screen_center":
+			return SCREEN_CENTER
+		_:
+			return _edge_random_position()
+
+
+func _resolve_direction(pattern_def: Dictionary, origin: Vector2) -> Vector2:
+	var aim: String = String(pattern_def.get("aim", "player"))
+	match aim:
+		"player":
+			if is_instance_valid(player):
+				var d: Vector2 = player.global_position - origin
+				if d.length_squared() > 0.0:
+					return d.normalized()
+			return Vector2.DOWN
+		"outward":
+			var d2: Vector2 = origin - SCREEN_CENTER
+			if d2.length_squared() > 0.0:
+				return d2.normalized()
+			return Vector2.DOWN
+		"fixed_down":
+			return Vector2.DOWN
+		"fixed_up":
+			return Vector2.UP
+		_:
+			return Vector2.DOWN
+
+
+func _edge_random_position() -> Vector2:
+	var edge: int = randi() % 4
+	var pos: Vector2 = Vector2.ZERO
 	match edge:
-		0: # Top
+		0:
 			pos.x = randf_range(SPAWN_MARGIN, SCREEN_WIDTH - SPAWN_MARGIN)
 			pos.y = -SPAWN_MARGIN
-		1: # Right
+		1:
 			pos.x = SCREEN_WIDTH + SPAWN_MARGIN
 			pos.y = randf_range(SPAWN_MARGIN, SCREEN_HEIGHT - SPAWN_MARGIN)
-		2: # Bottom
+		2:
 			pos.x = randf_range(SPAWN_MARGIN, SCREEN_WIDTH - SPAWN_MARGIN)
 			pos.y = SCREEN_HEIGHT + SPAWN_MARGIN
-		3: # Left
+		3:
 			pos.x = -SPAWN_MARGIN
 			pos.y = randf_range(SPAWN_MARGIN, SCREEN_HEIGHT - SPAWN_MARGIN)
-	
 	return pos
 
-func stop_spawning() -> void:
-	spawning = false
+
+# === 子弹实例化 ================================================================
+
+func _spawn_one(spawn_pos: Vector2, direction: Vector2, bullet_speed: float) -> void:
+	if bullet_scene == null:
+		push_error("[BulletSpawner] bullet_scene 未配置")
+		return
+	if direction == Vector2.ZERO:
+		direction = Vector2.DOWN
+	_bullet_counter += 1
+	var bullet: Node = bullet_scene.instantiate()
+	bullet.name = "bullet_%d" % _bullet_counter
+	bullet.global_position = spawn_pos
+	if bullet.has_method("init"):
+		bullet.init(spawn_pos, direction.normalized(), bullet_speed)
+	get_parent().add_child(bullet)

--- a/bullet/bullet_spawner.gd
+++ b/bullet/bullet_spawner.gd
@@ -65,7 +65,7 @@ func _fire_fan(pattern_def: Dictionary, bullet_speed: float) -> void:
 		base_dir = Vector2.DOWN
 	var spread_rad: float = deg_to_rad(spread_deg)
 	for i in range(count):
-		var t: float = 0.0 if count == 1 else float(i) / float(count - 1)
+		var t: float = 0.5 if count == 1 else float(i) / float(count - 1)
 		var angle: float = -spread_rad * 0.5 + t * spread_rad
 		var dir: Vector2 = base_dir.rotated(angle)
 		_spawn_one(origin, dir, bullet_speed)
@@ -95,17 +95,18 @@ func _fire_line_burst(pattern_def: Dictionary, bullet_speed: float) -> void:
 func _run_line_burst(pattern_def: Dictionary, bullet_speed: float, token: int) -> void:
 	var count: int = maxi(1, int(pattern_def.get("count", 1)))
 	var interval: float = maxf(0.0, float(pattern_def.get("interval", 0.1)))
+	var origin: Vector2 = _resolve_spawn(pattern_def)
 	for i in range(count):
 		if token != _inflight_token:
 			return
 		if not is_instance_valid(player):
 			return
-		var origin: Vector2 = _resolve_spawn(pattern_def)
 		var direction: Vector2 = _resolve_direction(pattern_def, origin)
 		_spawn_one(origin, direction, bullet_speed)
-		if i == count - 1 or interval <= 0.0:
+		if i == count - 1:
 			break
-		await get_tree().create_timer(interval, false).timeout
+		if interval > 0.0:
+			await get_tree().create_timer(interval, false).timeout
 
 
 # === 解析 spawn / aim ==========================================================

--- a/bullet/wave_config.json
+++ b/bullet/wave_config.json
@@ -1,0 +1,58 @@
+{
+  "patterns": {
+    "single_aimed": {
+      "shape": "single",
+      "spawn": "edge_random",
+      "aim": "player"
+    },
+    "fan_5": {
+      "shape": "fan",
+      "count": 5,
+      "spread_deg": 40.0,
+      "spawn": "edge_random",
+      "aim": "player"
+    },
+    "fan_3_tight": {
+      "shape": "fan",
+      "count": 3,
+      "spread_deg": 18.0,
+      "spawn": "edge_random",
+      "aim": "player"
+    },
+    "ring_12": {
+      "shape": "ring",
+      "count": 12,
+      "spawn": "near_player",
+      "spawn_distance": 320.0,
+      "aim": "outward"
+    },
+    "ring_8_center": {
+      "shape": "ring",
+      "count": 8,
+      "spawn": "screen_center",
+      "aim": "outward",
+      "rotation_offset_deg": 22.5
+    },
+    "line_burst_3": {
+      "shape": "line_burst",
+      "count": 3,
+      "interval": 0.10,
+      "spawn": "edge_random",
+      "aim": "player"
+    }
+  },
+
+  "waves": [
+    { "id": "w1_warmup",   "prep_time": 2.0, "duration": 15.0, "fire_interval": 1.20, "bullet_speed": 100.0, "pattern": "single_aimed" },
+    { "id": "w2_steady",   "prep_time": 3.0, "duration": 18.0, "fire_interval": 1.00, "bullet_speed": 110.0, "pattern": "single_aimed" },
+    { "id": "w3_fan",      "prep_time": 4.0, "duration": 20.0, "fire_interval": 1.40, "bullet_speed": 120.0, "pattern": "fan_3_tight" },
+    { "id": "w4_volley",   "prep_time": 4.0, "duration": 22.0, "fire_interval": 0.95, "bullet_speed": 130.0, "pattern": "line_burst_3" },
+    { "id": "w5_ring",     "prep_time": 5.0, "duration": 24.0, "fire_interval": 2.20, "bullet_speed": 140.0, "pattern": "ring_12" },
+    { "id": "w6_storm",    "prep_time": 4.0, "duration": 30.0, "fire_interval": 0.75, "bullet_speed": 150.0, "pattern": "fan_5" },
+    { "id": "w7_pressure", "prep_time": 5.0, "duration": 30.0, "fire_interval": 1.80, "bullet_speed": 160.0, "pattern": "ring_8_center" }
+  ],
+
+  "loop_from_wave": 4,
+  "loop_speed_step": 10.0,
+  "loop_interval_mul": 0.95
+}

--- a/bullet/wave_director.gd
+++ b/bullet/wave_director.gd
@@ -1,0 +1,184 @@
+extends Node
+
+# 弹幕波次驱动器：从 wave_config.json 读取波次与弹幕群（pattern）配置，
+# 驱动 BulletSpawner 在每一波的发射阶段按指定 pattern 发射弹幕群。
+#
+# 波次状态机：PREP --(prep_time)--> FIRING --(duration)--> 下一波 PREP
+# 当跑完最后一波后从 loop_from_wave 折回，并按 loop_speed_step / loop_interval_mul 递增难度。
+
+const CONFIG_PATH: String = "res://bullet/wave_config.json"
+const WAIT_STEP_SEC: float = 0.05
+
+@export var spawner_path: NodePath = NodePath("../bullet_spawner")
+@export var debug_skip_key: bool = true
+
+var _patterns: Dictionary = {}
+var _waves: Array = []
+var _loop_from_wave: int = 0
+var _loop_speed_step: float = 0.0
+var _loop_interval_mul: float = 1.0
+
+var _spawner: Node = null
+var _current_index: int = 0
+var _loop_count: int = 0
+var _running: bool = true
+var _state: String = "idle"  # idle / prep / firing
+var _phase_token: int = 0
+var _skip_cooldown: float = 0.0
+
+
+func _ready() -> void:
+	_spawner = get_node_or_null(spawner_path)
+	if _spawner == null:
+		push_error("[WaveDirector] 未找到 BulletSpawner: %s" % spawner_path)
+		return
+	_load_config()
+	if _waves.is_empty():
+		push_warning("[WaveDirector] 波次配置为空，弹幕系统不会生成子弹")
+		return
+	_run_wave_loop()
+
+
+func _load_config() -> void:
+	var file := FileAccess.open(CONFIG_PATH, FileAccess.READ)
+	if file == null:
+		push_error("[WaveDirector] 无法打开 %s" % CONFIG_PATH)
+		return
+	var json := JSON.new()
+	var parse_err := json.parse(file.get_as_text())
+	file.close()
+	if parse_err != OK:
+		push_error("[WaveDirector] 解析失败: %s" % json.get_error_message())
+		return
+	var data: Dictionary = json.data
+	_patterns = data.get("patterns", {})
+	_waves = data.get("waves", [])
+	_loop_from_wave = int(data.get("loop_from_wave", 0))
+	_loop_speed_step = float(data.get("loop_speed_step", 0.0))
+	_loop_interval_mul = float(data.get("loop_interval_mul", 1.0))
+	print("[WaveDirector] 配置加载完成：%d 个 pattern，%d 个 wave" % [
+		_patterns.size(),
+		_waves.size()
+	])
+
+
+func _run_wave_loop() -> void:
+	while _running:
+		if _waves.is_empty():
+			return
+		if _current_index >= _waves.size():
+			_current_index = clampi(_loop_from_wave, 0, _waves.size() - 1)
+			_loop_count += 1
+			print("[WaveDirector] 进入第 %d 轮循环，回到第 %d 波" % [_loop_count, _current_index])
+		await _execute_wave(_current_index)
+		_current_index += 1
+
+
+func _execute_wave(index: int) -> void:
+	var wave_def: Dictionary = _waves[index]
+	var wave_id: String = String(wave_def.get("id", "w%d" % index))
+	var prep_time: float = maxf(0.0, float(wave_def.get("prep_time", 0.0)))
+	var duration: float = maxf(0.0, float(wave_def.get("duration", 0.0)))
+	var fire_interval_base: float = maxf(0.05, float(wave_def.get("fire_interval", 1.0)))
+	var bullet_speed_base: float = float(wave_def.get("bullet_speed", 100.0))
+	var pattern_id: String = String(wave_def.get("pattern", ""))
+	var pattern_def: Dictionary = _patterns.get(pattern_id, {})
+	if pattern_def.is_empty():
+		push_warning("[WaveDirector] 波次 %s 引用的 pattern 不存在: %s" % [wave_id, pattern_id])
+
+	var fire_interval: float = maxf(0.05, fire_interval_base * pow(_loop_interval_mul, _loop_count))
+	var bullet_speed: float = bullet_speed_base + _loop_speed_step * _loop_count
+
+	_phase_token += 1
+	var token: int = _phase_token
+
+	# === PREP ===
+	_state = "prep"
+	EventBus.on_wave_prep_started.emit({
+		"wave_id": wave_id,
+		"index": index,
+		"loop": _loop_count,
+		"prep_time": prep_time,
+		"duration": duration,
+		"pattern_id": pattern_id,
+	})
+	print("[WaveDirector] 准备波次 %s（loop=%d）：prep=%.1fs，duration=%.1fs，interval=%.2fs，speed=%.0f，pattern=%s" % [
+		wave_id, _loop_count, prep_time, duration, fire_interval, bullet_speed, pattern_id
+	])
+	var prep_cancelled: bool = await _wait_seconds(prep_time, token)
+	if prep_cancelled or not _running:
+		_state = "idle"
+		return
+
+	# === FIRING ===
+	_state = "firing"
+	EventBus.on_wave_started.emit({
+		"wave_id": wave_id,
+		"index": index,
+		"loop": _loop_count,
+		"duration": duration,
+		"fire_interval": fire_interval,
+		"bullet_speed": bullet_speed,
+		"pattern_id": pattern_id,
+	})
+	print("[WaveDirector] 开始发射 %s" % wave_id)
+
+	var elapsed: float = 0.0
+	while elapsed < duration and _running and _phase_token == token:
+		if _spawner != null and _spawner.has_method("fire_pattern"):
+			_spawner.fire_pattern(pattern_def, bullet_speed)
+		var step: float = minf(fire_interval, maxf(0.0, duration - elapsed))
+		if step <= 0.0:
+			break
+		var cancelled: bool = await _wait_seconds(step, token)
+		if cancelled:
+			break
+		elapsed += step
+
+	# 切到下一波前清理 spawner 中尚未发射完的 burst
+	if _spawner != null and _spawner.has_method("cancel_inflight"):
+		_spawner.cancel_inflight()
+
+	EventBus.on_wave_ended.emit({
+		"wave_id": wave_id,
+		"index": index,
+		"loop": _loop_count,
+	})
+	print("[WaveDirector] 波次结束 %s" % wave_id)
+	_state = "idle"
+
+
+# 可被 _phase_token 变化中断的等待。返回 true 表示被中断。
+func _wait_seconds(seconds: float, token: int) -> bool:
+	var remaining: float = seconds
+	while remaining > 0.0:
+		if _phase_token != token or not _running:
+			return true
+		var step: float = minf(WAIT_STEP_SEC, remaining)
+		await get_tree().create_timer(step, false).timeout
+		remaining -= step
+	return false
+
+
+# ─── 调试接口 ─────────────────────────────────────────────────────────────────
+
+func _process(delta: float) -> void:
+	if _skip_cooldown > 0.0:
+		_skip_cooldown -= delta
+	if debug_skip_key and Input.is_key_pressed(KEY_N) and _skip_cooldown <= 0.0:
+		_request_skip_to_next_wave()
+
+
+func _request_skip_to_next_wave() -> void:
+	_skip_cooldown = 0.5
+	_phase_token += 1
+	if _spawner != null and _spawner.has_method("cancel_inflight"):
+		_spawner.cancel_inflight()
+	print("[WaveDirector] 调试：手动跳到下一波")
+
+
+func stop() -> void:
+	_running = false
+	_phase_token += 1
+	if _spawner != null and _spawner.has_method("cancel_inflight"):
+		_spawner.cancel_inflight()

--- a/bullet/wave_director.gd
+++ b/bullet/wave_director.gd
@@ -10,7 +10,7 @@ const CONFIG_PATH: String = "res://bullet/wave_config.json"
 const WAIT_STEP_SEC: float = 0.05
 
 @export var spawner_path: NodePath = NodePath("../bullet_spawner")
-@export var debug_skip_key: bool = true
+@export var debug_skip_key: bool = false
 
 var _patterns: Dictionary = {}
 var _waves: Array = []

--- a/bullet/wave_director.gd.uid
+++ b/bullet/wave_director.gd.uid
@@ -1,0 +1,1 @@
+uid://xa8jl5dnnwoy

--- a/game_over/game_over_ui.gd
+++ b/game_over/game_over_ui.gd
@@ -2,6 +2,7 @@ extends CanvasLayer
 
 @onready var player: Node = get_node("/root/main/player")
 @onready var bullet_spawner: Node = get_node("/root/main/bullet_spawner")
+@onready var wave_director: Node = get_node_or_null("/root/main/wave_director")
 @onready var overlay: ColorRect = $overlay
 @onready var again_label: Label = $again_label
 
@@ -21,9 +22,11 @@ func _on_health_depleted() -> void:
 	
 	is_game_over = true
 	
-	# Stop bullet spawning
-	if bullet_spawner and bullet_spawner.has_method("stop_spawning"):
-		bullet_spawner.stop_spawning()
+	# Stop wave progression and any in-flight bursts
+	if wave_director and wave_director.has_method("stop"):
+		wave_director.stop()
+	if bullet_spawner and bullet_spawner.has_method("cancel_inflight"):
+		bullet_spawner.cancel_inflight()
 	
 	# Destroy all bullets
 	for bullet in get_tree().get_nodes_in_group("bullet"):

--- a/main.tscn
+++ b/main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=10 format=3 uid="uid://byoiqp8nrncx"]
+[gd_scene load_steps=13 format=3 uid="uid://byoiqp8nrncx"]
 
 [ext_resource type="PackedScene" uid="uid://bg1qf8y10f7qy" path="res://start/background.tscn" id="1_bg"]
 [ext_resource type="PackedScene" uid="uid://c54q3qhqhcyey" path="res://start/hint_label.tscn" id="2_label"]
 [ext_resource type="PackedScene" uid="uid://player001" path="res://player/player.tscn" id="3_player"]
 [ext_resource type="PackedScene" uid="uid://bullet001" path="res://bullet/bullet.tscn" id="4_bullet"]
 [ext_resource type="Script" path="res://bullet/bullet_spawner.gd" id="5_spawner"]
+[ext_resource type="Script" path="res://bullet/wave_director.gd" id="5b_wave_director"]
 [ext_resource type="Texture2D" uid="uid://41m4vh7uubtb" path="res://player/joystick_base.png" id="6_joystick_base"]
 [ext_resource type="Texture2D" uid="uid://euu7lp4pc3a4" path="res://player/joystick_knob.png" id="7_joystick_knob"]
 [ext_resource type="PackedScene" uid="uid://healthui001" path="res://health/health_ui.tscn" id="8_health_ui"]
@@ -17,6 +18,10 @@
 [node name="bullet_spawner" type="Node" parent="."]
 script = ExtResource("5_spawner")
 bullet_scene = ExtResource("4_bullet")
+
+[node name="wave_director" type="Node" parent="."]
+script = ExtResource("5b_wave_director")
+spawner_path = NodePath("../bullet_spawner")
 
 [node name="background" parent="." unique_id=978789563 instance=ExtResource("1_bg")]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

当前游戏难度不会随时间变化，玩家不断升级而弹幕始终是固定 1 秒一颗的追踪子弹，缺少对抗节奏。本 PR 引入一个**配置驱动的分波次弹幕系统**，按 Slack 中确认的简化方案落地：每一波可配置准备时间、持续时间、发射间隔、子弹速度，并支持引用具名"弹幕群（pattern）"配置生成特殊形状。

## 改动概览

### 新增

- `bullet/wave_config.json` — 弹幕群（patterns）+ 波次表（waves）+ 末波循环参数。
- `bullet/wave_director.gd` — 波次状态机：`PREP → FIRING → next`，跑完末波后从 `loop_from_wave` 循环并按 `loop_speed_step` / `loop_interval_mul` 递增难度。

### 重构

- `bullet/bullet_spawner.gd` — 去掉自驱循环和 `spawn_interval` / `initial_delay`，改为被动 API：
  - `fire_pattern(pattern_def, bullet_speed)`：按 shape 解析出生位置与方向，立即发射。
  - `cancel_inflight()`：切波时取消进行中的 `line_burst` 协程，避免上一波尾巴溢出。
- `bullet/bullet.gd` — `init(spawn_pos, dir, speed)`，方向与速度全由 spawner 计算，子弹本体保持简单。
- `ability/event_bus.gd` — 新增 `on_wave_prep_started` / `on_wave_started` / `on_wave_ended` 信号，留给后续 UI 横幅。
- `main.tscn` — 挂载 `wave_director` 节点。
- `game_over/game_over_ui.gd` — 死亡时停止 `wave_director` 并 `cancel_inflight()`（替换原先的 `BulletSpawner.stop_spawning()`）。

## 配置语义

### Wave 字段

| 字段 | 说明 |
|---|---|
| `prep_time` | 本波正式开始前的等待秒数（不发射） |
| `duration` | 本波发射阶段持续秒数 |
| `fire_interval` | 本波内每次"按 pattern 发射一组弹幕"的间隔 |
| `bullet_speed` | 本波所有子弹的初速度 |
| `pattern` | 引用 `patterns` 中的某个键 |

### Pattern 形状

- `single`：单发。
- `fan`：扇形 N 发，参数 `count`、`spread_deg`。
- `ring`：环形 N 发，参数 `count`、`spawn_distance`、`rotation_offset_deg`。
- `line_burst`：同方向连发 N 颗，按 `interval` 间隔逐颗（每颗即时重新瞄准玩家）。

`spawn` 支持 `edge_random` / `near_player` / `screen_center`，`aim` 支持 `player` / `outward` / `fixed_down` / `fixed_up`。

### 末波循环

跑完最后一波后从 `loop_from_wave` 折回，每循环一次：
- `bullet_speed += loop_speed_step`
- `fire_interval *= loop_interval_mul`

## 调试

`wave_director.gd` 在游戏内监听 **N 键** 作为"跳到下一波"的调试键（按一次 0.5s 防抖），便于手动测试不同 pattern。

## 验证

### 1. Headless 启动 + 主场景加载

```
[WaveDirector] 配置加载完成：6 个 pattern，7 个 wave
[WaveDirector] 准备波次 w1_warmup（loop=0）：prep=2.0s，duration=15.0s，interval=1.20s，speed=100，pattern=single_aimed
```

### 2. Web 导出（CI 对齐）

`godot --headless --export-release "Web" build/web/index.html` 通过，无 error / warning。

### 3. 完整波次推进 + 末波循环（短配置加速跑）

把所有 wave 改为 `prep=0.3s, duration=1.0s` 后跑 20s，得到 7 波依次完成 → 进入第 1 轮循环 → 回到 `w5_ring` 且 `interval` 从 2.20 → 2.09（×0.95）、`speed` 从 140 → 150（+10），符合配置语义：

```
[WaveDirector] 波次结束 w7_pressure
[WaveDirector] 进入第 1 轮循环，回到第 4 波
[WaveDirector] 准备波次 w5_ring（loop=1）：prep=0.3s，duration=1.0s，interval=2.09s，speed=150，pattern=ring_12
```

### 4. 浏览器手动测试

7 个波次的视觉表现各不相同，全部符合配置语义：

| 波次 | 形状 |
|---|---|
| w1 单发追踪 | [w1 single](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_wave1_single.png) |
| w3 紧密扇形 | [w3 fan](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_wave3_fan.png) |
| w4 line burst 连射 | [w4 burst](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_wave4_burst.png) |
| w5 环绕玩家 12 发 | [w5 ring](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_wave5_ring.png) |
| w7 屏幕中心 8 发辐射 | [w7 center ring](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_wave7_center_ring.png) |

### 5. 端到端视频演示（按 N 键依次跳过 7 个波次）

为避免演示期间被升级 UI 频繁打断，录制时**临时**将 `xp_per_bullet_hit` 改为 0（已在录制完成后恢复）。视频在 00:20–00:32 段完整、清晰地展示了 7 个波次的形状切换：

[wave_director_demo_clean.mp4](https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwave_director_demo_clean.mp4)

视频复核结论：所有 7 个波次的形状切换都清晰可见、画面流畅、无脚本错误。

## 不在本 PR 范围

- 波次提示 UI 横幅（信号已就位，UI 后续单独实现）。
- 与 `Experience` / `AbilityManager` 状态联动的动态难度调节（保持系统当前的"纯配置驱动"特征）。
- 更复杂的弹幕群形状（如 spiral、波浪）。

## 风险与回滚

- 改动集中在 `bullet/` + `main.tscn` + `game_over_ui.gd`。能力系统、XP、UI 全部 0 改动。
- 回滚：直接 revert 此 PR 即可恢复旧的 `BulletSpawner` 自循环模式。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://w1777342061-oij242592.slack.com/archives/C0B08H7RTUJ/p1777364204891009?thread_ts=1777364204.891009&cid=C0B08H7RTUJ)

<div><a href="https://cursor.com/agents/bc-e0ec6908-f006-533a-ad51-6e281c4797bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0ec6908-f006-533a-ad51-6e281c4797bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

