### PR TITLE
ci: per-PR Pages 预览部署（review 通过后触发）

### DIFF
--- a/.github/actions/build-godot-web/action.yml
+++ b/.github/actions/build-godot-web/action.yml
@@ -1,0 +1,63 @@
+name: Build Godot Web
+description: |
+  Build the Godot Web export for ShieldCore.
+  Reusable composite action shared by main deployment and PR preview workflows.
+
+inputs:
+  godot-version:
+    description: Godot release tag (e.g. 4.6.2-stable).
+    required: false
+    default: 4.6.2-stable
+  godot-template-version:
+    description: Export template directory name (dot form, e.g. 4.6.2.stable).
+    required: false
+    default: 4.6.2.stable
+  output-dir:
+    description: Directory to write the Web export into.
+    required: false
+    default: build/web
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y wget unzip
+
+    - name: Download Godot
+      shell: bash
+      run: |
+        wget -q "https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}_linux.x86_64.zip" -O godot.zip
+        unzip -q godot.zip
+        sudo mv "Godot_v${{ inputs.godot-version }}_linux.x86_64" /usr/local/bin/godot
+        sudo chmod +x /usr/local/bin/godot
+
+    - name: Download export templates
+      shell: bash
+      run: |
+        wget -q "https://github.com/godotengine/godot/releases/download/${{ inputs.godot-version }}/Godot_v${{ inputs.godot-version }}_export_templates.tpz" -O templates.tpz
+        mkdir -p ~/.local/share/godot/export_templates/${{ inputs.godot-template-version }}
+        unzip -q templates.tpz
+        mv templates/* ~/.local/share/godot/export_templates/${{ inputs.godot-template-version }}/
+
+    - name: Download CJK font (Noto Sans SC)
+      shell: bash
+      run: |
+        mkdir -p assets/fonts
+        wget -q "https://github.com/google/fonts/raw/main/ofl/notosanssc/NotoSansSC%5Bwght%5D.ttf" -O assets/fonts/NotoSansSC.ttf
+
+    - name: Import project
+      shell: bash
+      run: |
+        mkdir -p "${{ inputs.output-dir }}"
+        godot --headless --import || true
+
+    - name: Export Web build
+      shell: bash
+      run: |
+        godot --headless --export-release "Web" "${{ inputs.output-dir }}/index.html"
+        ls -la "${{ inputs.output-dir }}"
+
+    - name: Add .nojekyll
+      shell: bash
+      run: touch "${{ inputs.output-dir }}/.nojekyll"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,9 +36,14 @@ There are no unit tests, linters, or formatters configured. Do not introduce new
 - **Web export** (mirrors CI; requires the matching export templates installed for 4.6.2.stable):
   `godot --headless --export-release "Web" build/web/index.html`
 
-## CI / deployment (`.github/workflows/deploy-pages.yml`)
+## CI / deployment
 
-Push to `main` → workflow downloads Godot **4.6.2-stable** + export templates, fetches Noto Sans SC into `assets/fonts/`, runs `--import`, exports the `Web` preset to `build/web/`, adds `.nojekyll`, and deploys to GitHub Pages. When changing the engine version, bump both `GODOT_VERSION` (e.g. `4.6.2-stable`) and `GODOT_TEMPLATE_VERSION` (dot form, e.g. `4.6.2.stable`), and update `config/features` in `project.godot`.
+The shared build steps live in the composite action `.github/actions/build-godot-web/`. It downloads Godot **4.6.2-stable** + export templates, fetches Noto Sans SC into `assets/fonts/`, runs `--import`, exports the `Web` preset to `build/web/`, and adds `.nojekyll`. When changing the engine version, bump both `GODOT_VERSION` (e.g. `4.6.2-stable`) and `GODOT_TEMPLATE_VERSION` (dot form, e.g. `4.6.2.stable`) in the workflow files, and update `config/features` in `project.godot`.
+
+Two workflows publish to the **`gh-pages` branch** (Pages source must be set to `Branch: gh-pages / root` in the repo settings):
+
+- `.github/workflows/deploy-pages.yml` — on every push to `main`, builds the Web export and replaces the gh-pages root, while preserving `pr-preview/` so open previews stay alive.
+- `.github/workflows/pr-preview.yml` — when a PR receives an **approving review** (`pull_request_review` with `state == approved`), builds the PR head and publishes it to `gh-pages` under `pr-preview/pr-<number>/`, then comments the preview URL on the PR. When the PR is closed (merged or not), the same workflow removes that sub-directory. Forks are skipped because they do not have write access to the gh-pages branch.
 
 ## Conventions
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,13 +5,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# We publish to the `gh-pages` branch directly (instead of using the
+# GitHub Pages deployment API) so that we can host both the main build and
+# many PR-preview builds at once, each in its own sub-directory. Switching
+# the Pages source to "Branch: gh-pages / root" is required in the
+# repository settings (Settings → Pages → Build and deployment).
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
+# Serialize main deployments so we never push two main builds concurrently.
+# PR previews use their own concurrency group so they can run in parallel.
 concurrency:
-  group: pages
+  group: gh-pages-main
   cancel-in-progress: true
 
 env:
@@ -19,7 +24,7 @@ env:
   GODOT_TEMPLATE_VERSION: 4.6.2.stable
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,53 +32,65 @@ jobs:
         with:
           lfs: true
 
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y wget unzip
-
-      - name: Download Godot
-        run: |
-          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip" -O godot.zip
-          unzip -q godot.zip
-          mv "Godot_v${GODOT_VERSION}_linux.x86_64" /usr/local/bin/godot
-          chmod +x /usr/local/bin/godot
-
-      - name: Download export templates
-        run: |
-          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_export_templates.tpz" -O templates.tpz
-          mkdir -p ~/.local/share/godot/export_templates/${GODOT_TEMPLATE_VERSION}
-          unzip -q templates.tpz
-          mv templates/* ~/.local/share/godot/export_templates/${GODOT_TEMPLATE_VERSION}/
-
-      - name: Download CJK font (Noto Sans SC)
-        run: |
-          mkdir -p assets/fonts
-          wget -q "https://github.com/google/fonts/raw/main/ofl/notosanssc/NotoSansSC%5Bwght%5D.ttf" -O assets/fonts/NotoSansSC.ttf
-
-      - name: Import project
-        run: |
-          mkdir -p build/web
-          godot --headless --import || true
-
-      - name: Export Web build
-        run: |
-          godot --headless --export-release "Web" build/web/index.html
-          ls -la build/web
-
-      - name: Add .nojekyll
-        run: touch build/web/.nojekyll
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Build Godot Web export
+        uses: ./.github/actions/build-godot-web
         with:
-          path: build/web
+          godot-version: ${{ env.GODOT_VERSION }}
+          godot-template-version: ${{ env.GODOT_TEMPLATE_VERSION }}
+          output-dir: build/web
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # Publish the freshly built export to the root of the `gh-pages` branch
+      # while preserving the `pr-preview/` directory (which holds open PR
+      # previews) so we don't wipe those builds whenever main is redeployed.
+      - name: Publish to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BUILD_DIR="$(pwd)/build/web"
+          WORK_DIR="$(mktemp -d)"
+
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Clone (shallow) the gh-pages branch if it exists, otherwise create
+          # a fresh orphan branch.
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
+            git clone --depth=1 --branch gh-pages "$REPO_URL" "$WORK_DIR"
+          else
+            git clone --depth=1 "$REPO_URL" "$WORK_DIR"
+            cd "$WORK_DIR"
+            git checkout --orphan gh-pages
+            git rm -rf . >/dev/null 2>&1 || true
+            cd - >/dev/null
+          fi
+
+          cd "$WORK_DIR"
+
+          # Wipe everything in the branch root EXCEPT the pr-preview/ directory
+          # and the .git metadata, so each main deploy is a clean slate at
+          # the root while still preserving open PR preview builds.
+          shopt -s dotglob nullglob
+          for entry in *; do
+            case "$entry" in
+              .git|pr-preview) ;;
+              *) rm -rf -- "$entry" ;;
+            esac
+          done
+          shopt -u dotglob nullglob
+
+          # Copy the freshly built export into the branch root.
+          cp -R "$BUILD_DIR"/. ./
+
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+
+          git commit -m "deploy(main): ${GITHUB_SHA}"
+          git push origin gh-pages

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -93,4 +93,24 @@ jobs:
           fi
 
           git commit -m "deploy(main): ${GITHUB_SHA}"
-          git push origin gh-pages
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:gh-pages; then
+              echo "Published to gh-pages on attempt ${attempt}."
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to publish to gh-pages after ${attempt} attempts."
+              exit 1
+            fi
+
+            echo "Push rejected, fetching latest gh-pages and rebasing before retry ${attempt}..."
+            git fetch origin gh-pages || true
+
+            if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+              git rebase origin/gh-pages
+            fi
+
+            sleep $((attempt * 2))
+          done

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,259 @@
+name: PR preview deploy
+
+# Build a Godot Web export of the PR branch and publish it to a per-PR
+# sub-directory under the `gh-pages` branch (e.g. `pr-preview/pr-12/`).
+# The preview is built only AFTER the PR receives an approving review, so
+# reviewers/maintainers can manually test it before clicking merge.
+#
+# The same workflow also cleans up the preview directory once the PR is
+# closed (merged or not).
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
+
+# We push to the `gh-pages` branch and comment on the PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize per-PR deploys so two events on the same PR do not race.
+concurrency:
+  group: gh-pages-preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  GODOT_VERSION: 4.6.2-stable
+  GODOT_TEMPLATE_VERSION: 4.6.2.stable
+
+jobs:
+  deploy-preview:
+    name: Deploy preview on approval
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'approved' &&
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
+
+      - name: Compute preview metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          # Pages URL for a project site lives at https://<owner>.github.io/<repo>/.
+          # We host previews under pr-preview/pr-<n>/.
+          BASE_PATH="/${REPO_NAME}/pr-preview/pr-${PR_NUMBER}/"
+          PREVIEW_URL="https://${OWNER,,}.github.io${BASE_PATH}"
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "base_path=${BASE_PATH}"
+            echo "preview_url=${PREVIEW_URL}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build Godot Web export
+        uses: ./.github/actions/build-godot-web
+        with:
+          godot-version: ${{ env.GODOT_VERSION }}
+          godot-template-version: ${{ env.GODOT_TEMPLATE_VERSION }}
+          output-dir: build/web
+
+      - name: Publish preview to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          BUILD_DIR="$(pwd)/build/web"
+          WORK_DIR="$(mktemp -d)"
+
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
+            git clone --depth=1 --branch gh-pages "$REPO_URL" "$WORK_DIR"
+          else
+            git clone --depth=1 "$REPO_URL" "$WORK_DIR"
+            cd "$WORK_DIR"
+            git checkout --orphan gh-pages
+            git rm -rf . >/dev/null 2>&1 || true
+            cd - >/dev/null
+          fi
+
+          cd "$WORK_DIR"
+
+          TARGET_DIR="pr-preview/pr-${PR_NUMBER}"
+          rm -rf "$TARGET_DIR"
+          mkdir -p "$TARGET_DIR"
+          cp -R "$BUILD_DIR"/. "$TARGET_DIR"/
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+
+          git commit -m "preview(pr-${PR_NUMBER}): ${GITHUB_SHA}"
+
+          # Retry push a few times to cope with concurrent gh-pages updates.
+          for attempt in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed, rebasing and retrying..."
+            git fetch origin gh-pages
+            git rebase origin/gh-pages || { git rebase --abort || true; sleep $((attempt*2)); }
+          done
+          echo "Failed to push gh-pages after retries." >&2
+          exit 1
+
+      - name: Comment preview link on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.meta.outputs.preview_url }}
+          PR_NUMBER:   ${{ steps.meta.outputs.pr_number }}
+          HEAD_SHA:    ${{ github.event.pull_request.head.sha }}
+          HEAD_REF:    ${{ github.event.pull_request.head.ref }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = '<!-- shield-core-pr-preview -->';
+            const url    = process.env.PREVIEW_URL;
+            const sha    = process.env.HEAD_SHA;
+            const ref    = process.env.HEAD_REF;
+            const prNum  = Number(process.env.PR_NUMBER);
+            const body = [
+              marker,
+              '### 🕹️ PR 预览构建完成',
+              '',
+              `- 测试地址: ${url}`,
+              `- 分支: \`${ref}\``,
+              `- 提交: \`${sha.slice(0, 7)}\``,
+              '',
+              'GitHub Pages CDN 缓存可能需要 1–2 分钟刷新。确认无误后再点击合并即可。',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: prNum,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNum,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    name: Cleanup preview on close
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove preview directory from gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          WORK_DIR="$(mktemp -d)"
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if ! git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
+            echo "gh-pages branch does not exist; nothing to clean."
+            exit 0
+          fi
+
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git clone --depth=1 --branch gh-pages "$REPO_URL" "$WORK_DIR"
+          cd "$WORK_DIR"
+
+          TARGET_DIR="pr-preview/pr-${PR_NUMBER}"
+          if [ ! -d "$TARGET_DIR" ]; then
+            echo "No preview directory at ${TARGET_DIR}; nothing to clean."
+            exit 0
+          fi
+
+          git rm -rf "$TARGET_DIR"
+          # Drop the parent if it is now empty, just to keep things tidy.
+          if [ -d pr-preview ] && [ -z "$(ls -A pr-preview)" ]; then
+            rmdir pr-preview
+            git add -A
+          fi
+
+          git commit -m "preview(pr-${PR_NUMBER}): cleanup after PR close"
+
+          for attempt in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed, rebasing and retrying..."
+            git fetch origin gh-pages
+            git rebase origin/gh-pages || { git rebase --abort || true; sleep $((attempt*2)); }
+          done
+          exit 1
+
+      - name: Comment cleanup on PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = '<!-- shield-core-pr-preview -->';
+            const prNum  = Number(process.env.PR_NUMBER);
+            const body = [
+              marker,
+              '### 🧹 PR 预览已下线',
+              '',
+              'PR 已关闭，对应的预览构建已从 GitHub Pages 移除。',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: prNum,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNum,
+                body,
+              });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,7 +13,8 @@ on:
   pull_request:
     types: [closed]
 
-# We push to the `gh-pages` branch and comment on the PR.
+# Grant the maximum permissions needed by any job in this workflow; each job
+# then restricts itself further via job-level permissions blocks.
 permissions:
   contents: write
   pull-requests: write
@@ -28,14 +29,22 @@ env:
   GODOT_TEMPLATE_VERSION: 4.6.2.stable
 
 jobs:
-  deploy-preview:
-    name: Deploy preview on approval
+  # ── Job 1: build ────────────────────────────────────────────────────────────
+  # Runs untrusted PR code (Godot import + export) with a read-only token so
+  # that a malicious PR cannot abuse write access during the build phase.
+  build-preview:
+    name: Build preview artifact
+    permissions:
+      contents: read
     if: >-
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved' &&
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    outputs:
+      pr_number:   ${{ steps.meta.outputs.pr_number }}
+      preview_url: ${{ steps.meta.outputs.preview_url }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -67,10 +76,34 @@ jobs:
           godot-template-version: ${{ env.GODOT_TEMPLATE_VERSION }}
           output-dir: build/web
 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-${{ steps.meta.outputs.pr_number }}
+          path: build/web
+          retention-days: 1
+
+  # ── Job 2: publish ──────────────────────────────────────────────────────────
+  # Runs only after a successful build; write tokens are confined to this job
+  # which never executes untrusted PR code.
+  publish-preview:
+    name: Publish preview and comment
+    needs: build-preview
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview-${{ needs.build-preview.outputs.pr_number }}
+          path: build/web
+
       - name: Publish preview to gh-pages branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.build-preview.outputs.pr_number }}
         run: |
           set -euo pipefail
 
@@ -105,7 +138,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "preview(pr-${PR_NUMBER}): ${GITHUB_SHA}"
+          git commit -m "preview(pr-${PR_NUMBER}): ${{ github.event.pull_request.head.sha }}"
 
           # Retry push a few times to cope with concurrent gh-pages updates.
           for attempt in 1 2 3 4 5; do
@@ -122,8 +155,8 @@ jobs:
       - name: Comment preview link on PR
         uses: actions/github-script@v7
         env:
-          PREVIEW_URL: ${{ steps.meta.outputs.preview_url }}
-          PR_NUMBER:   ${{ steps.meta.outputs.pr_number }}
+          PREVIEW_URL: ${{ needs.build-preview.outputs.preview_url }}
+          PR_NUMBER:   ${{ needs.build-preview.outputs.pr_number }}
           HEAD_SHA:    ${{ github.event.pull_request.head.sha }}
           HEAD_REF:    ${{ github.event.pull_request.head.ref }}
         with:
@@ -173,10 +206,17 @@ jobs:
 
   cleanup-preview:
     name: Cleanup preview on close
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Remove preview directory from gh-pages
+        id: remove
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -222,7 +262,7 @@ jobs:
           exit 1
 
       - name: Comment cleanup on PR
-        if: always()
+        if: success()
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -238,12 +278,15 @@ jobs:
               'PR 已关闭，对应的预览构建已从 GitHub Pages 移除。',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              issue_number: prNum,
-              per_page: 100,
-            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNum,
+                per_page: 100,
+              }
+            );
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -262,7 +262,7 @@ jobs:
           exit 1
 
       - name: Comment cleanup on PR
-        if: success()
+        if: steps.remove.outcome == 'success'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -145,12 +145,15 @@ jobs:
               'GitHub Pages CDN 缓存可能需要 1–2 分钟刷新。确认无误后再点击合并即可。',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              issue_number: prNum,
-              per_page: 100,
-            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNum,
+                per_page: 100,
+              }
+            );
             const existing = comments.find(c => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Godot 4.6.2 的 2D 竖屏游戏项目，核心玩法围绕玩家格挡、升级与能力组合。
 
+## 部署与 PR 预览
+
+- **主站**：推送到 `main` 后，`.github/workflows/deploy-pages.yml` 会重新构建 Web 包并发布到 `gh-pages` 分支根目录，访问 `https://<owner>.github.io/<repo>/`。
+- **PR 预览**：PR 收到 **approving review** 后，`.github/workflows/pr-preview.yml` 会构建 PR 当前 head，并把产物推送到 `gh-pages` 的 `pr-preview/pr-<number>/` 子目录，然后在 PR 上评论可测试地址。PR 关闭（合并或丢弃）时该子目录会自动清理。
+- **必要的人工配置**：仓库 Settings → Pages → Build and deployment 须将源切换为 **`Branch: gh-pages / root`**；首次工作流运行会自动创建 `gh-pages` 分支。
+
 ## 能力系统架构
 
 当前项目中的“能力系统”由能力定义、运行时实例、效果管线、联动解析和战斗消费层组成。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 目的

实现"PR 收到 review approve 后，自动在 GitHub Pages 上托管一份带 PR 标识的可测试地址"，方便手动测试通过后再合并。

## 总体方案

GitHub Pages 原生 Actions 部署模式（`actions/deploy-pages`）只能托管**一份**产物，无法同时承载主站和多个 PR 预览。本 PR 把发布通道从 "GitHub Actions" 切换到 "**Branch: `gh-pages`**" 模式，由两个工作流分别向同一个分支的不同子目录写入：

- `https://<owner>.github.io/<repo>/` — main 主站构建
- `https://<owner>.github.io/<repo>/pr-preview/pr-<number>/` — 每个 PR 的预览构建

PR 标识用 `pr-<number>`（数字稳定、不含斜杠），评论里同时显示分支名方便识别。

## 改动概览

- **新增** `.github/actions/build-godot-web/action.yml`：抽出 Godot Web 构建步骤为复用 composite action（下载 Godot 4.6.2 + 模板、Noto Sans SC、`--import`、`--export-release "Web"`、`.nojekyll`）。
- **重写** `.github/workflows/deploy-pages.yml`：
  - `push: main` 触发；
  - 构建后用纯 git 命令推送到 `gh-pages` 根目录；
  - **保留** `pr-preview/` 目录不删，避免主站重新部署时把开放中的 PR 预览一起抹掉。
- **新增** `.github/workflows/pr-preview.yml`：
  - `pull_request_review` 且 `state == approved` 时触发（≈ "review 成功之后"）；
  - 跳过 fork PR（无法写 gh-pages，避免 token 缺失报错）；
  - 构建 PR head → 发布到 `gh-pages:/pr-preview/pr-<number>/`；
  - 在 PR 上以 marker 评论形式贴出测试地址、分支名、commit short SHA，相同评论会被原地更新而非重复堆叠；
  - 推送有 5 次重试 + rebase，避免 main 部署同时写 gh-pages 时的并发冲突；
  - PR 关闭（无论是否合并）时自动清理对应预览目录并发出下线通知评论。
- **文档**：在 `README.md` 与 `.github/copilot-instructions.md` 增补部署与 PR 预览说明。

## 需要在仓库 Settings 里完成的人工步骤

合并这个 PR 之后，请在 GitHub 仓库 **Settings → Pages → Build and deployment** 中：

1. 把 **Source** 从 *GitHub Actions* 切换到 **Deploy from a branch**；
2. **Branch** 选择 `gh-pages` / `/ (root)`；保存。

首次工作流运行会自动创建 `gh-pages` 分支（首选 main 推送或一次手动 `workflow_dispatch`）。

## 本地验证

- 用 `actionlint 1.7.7` + `shellcheck 0.9` 校验两个 workflow 与 composite action：均通过。
- 用 `python3 -c yaml.safe_load` 校验 YAML 语法：通过。
- 在临时目录里 dry-run 复刻了 main 部署"保留 `pr-preview/`、清理根其它文件"的关键 shell 逻辑，验证：
  - `pr-preview/pr-7/`、`pr-preview/pr-9/` 旧 PR 预览未被破坏；
  - 旧主站资源 (`some_old_asset.js`) 被清理；
  - 新主站资源 (`main.js`、新 `index.html`) 就位。

## 端到端验证说明

工作流的真正端到端跑通必须在 GitHub 侧执行（涉及 `pull_request_review` 事件、Pages 设置切换、`gh-pages` 分支首次创建），无法在本仓库的开发环境内完整复现。建议合并后按以下顺序验证：

1. 切换 Pages 源为 `gh-pages / root`。
2. 触发一次 `Deploy Godot Web build to GitHub Pages` 的 `workflow_dispatch`，确认主站可访问。
3. 在任意一个测试 PR 上提交一份 approving review，观察 `PR preview deploy` workflow 跑完后是否出现"测试地址"评论，并打开链接验证。
4. 关闭 PR，确认预览被清理且评论被更新为"已下线"。

## 风险与回滚

- 风险点是 **Pages 源切换**——切换瞬间网站不可用，直到 `gh-pages` 上有第一份产物。建议在合并 PR 后立刻手动触发一次 main 部署。
- 回滚：把 Pages 源切回 *GitHub Actions* 并 revert 本 PR 即可，原工作流逻辑保留在 git 历史中可恢复。

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://w1777342061-oij242592.slack.com/archives/C0B08H7RTUJ/p1777376631920399?thread_ts=1777376631.920399&cid=C0B08H7RTUJ)

<div><a href="https://cursor.com/agents/bc-519ddd5f-fc27-5a46-809a-5440138e4261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519ddd5f-fc27-5a46-809a-5440138e4261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

