### PR TITLE
fix: resolve GDScript class_name self-reference compile errors

### DIFF
--- a/ability/ability_definition.gd
+++ b/ability/ability_definition.gd
@@ -22,8 +22,7 @@ func from_dict(data: Dictionary) -> void:
 	weight = data.get("weight", 100)
 	max_level = data.get("max_level", 1)
 	repeatable = data.get("repeatable", false)
-	if data.has("per_level"):
-		per_level = data.get("per_level", [])
+	per_level = (data["per_level"] as Array).duplicate() if data.has("per_level") else []
 
 
 ## 返回指定等级（1-based）的效果字典

--- a/ability/ability_definition.gd
+++ b/ability/ability_definition.gd
@@ -13,17 +13,17 @@ var repeatable: bool = false
 var per_level: Array = []    # Array[Dictionary]，每级的效果数据
 
 
-static func from_dict(data: Dictionary) -> AbilityDefinition:
-	var def := AbilityDefinition.new()
-	def.id = data.get("id", "")
-	def.display_name = data.get("name", "")
-	def.description = data.get("description", "")
-	def.rarity = data.get("rarity", 1)
-	def.weight = data.get("weight", 100)
-	def.max_level = data.get("max_level", 1)
-	def.repeatable = data.get("repeatable", false)
-	def.per_level = data.get("per_level", [])
-	return def
+## 从配置字典初始化自身（实例方法，避免 GDScript static 自引用编译问题）
+func from_dict(data: Dictionary) -> void:
+	id = data.get("id", "")
+	display_name = data.get("name", "")
+	description = data.get("description", "")
+	rarity = data.get("rarity", 1)
+	weight = data.get("weight", 100)
+	max_level = data.get("max_level", 1)
+	repeatable = data.get("repeatable", false)
+	if data.has("per_level"):
+		per_level = data.get("per_level", [])
 
 
 ## 返回指定等级（1-based）的效果字典

--- a/ability/ability_instance.gd
+++ b/ability/ability_instance.gd
@@ -2,12 +2,14 @@
 class_name AbilityInstance
 extends RefCounted
 
-var definition  # : AbilityDefinition (type omitted to avoid GDScript self-referencing compile issue)
+const AbilityDefinition = preload("res://ability/ability_definition.gd")
+
+var definition: AbilityDefinition
 var current_level: int = 1  # 保留字段兼容旧 UI/事件，固定为 1
 var stack_count: int = 1    # 重复获得次数，普通能力固定为 1
 
 
-func _init(def):  # def: AbilityDefinition
+func _init(def: AbilityDefinition):
 	definition = def
 	current_level = 1
 	stack_count = 1

--- a/ability/ability_instance.gd
+++ b/ability/ability_instance.gd
@@ -2,12 +2,12 @@
 class_name AbilityInstance
 extends RefCounted
 
-var definition: AbilityDefinition
+var definition  # : AbilityDefinition (type omitted to avoid GDScript self-referencing compile issue)
 var current_level: int = 1  # 保留字段兼容旧 UI/事件，固定为 1
 var stack_count: int = 1    # 重复获得次数，普通能力固定为 1
 
 
-func _init(def: AbilityDefinition) -> void:
+func _init(def):  # def: AbilityDefinition
 	definition = def
 	current_level = 1
 	stack_count = 1

--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -50,7 +50,8 @@ func _load_definitions() -> void:
 		return
 	file.close()
 	for entry in json.data.get("abilities", []):
-		var def := AbilityDefinition.from_dict(entry)
+		var def = AbilityDefinition.new()
+		def.from_dict(entry)
 		_definitions[def.id] = def
 	print("[AbilityManager] 已加载 %d 个能力定义" % _definitions.size())
 
@@ -76,7 +77,7 @@ func _try_show_pending_level_up() -> void:
 	_pending_level_up_selections -= 1
 	_selection_in_progress = true
 	print("[AbilityManager] 升级候选: %s" % [
-		candidates.map(func(d: AbilityDefinition) -> String: return d.id)
+		candidates.map(func(d) -> String: return d.id)
 	])
 	ability_selection_needed.emit(candidates)
 
@@ -98,7 +99,7 @@ func select_ability(ability_id: String) -> void:
 			_finish_level_up_selection()
 			return
 	else:
-		var def: AbilityDefinition = _definitions.get(ability_id, null)
+		var def = _definitions.get(ability_id, null)
 		if def == null:
 			push_error("[AbilityManager] 未知能力 id: %s" % ability_id)
 			_finish_level_up_selection()
@@ -192,7 +193,7 @@ func _generate_candidates(count: int) -> Array:
 
 func _build_candidate_pool() -> Array:
 	var pool: Array = []
-	for def: AbilityDefinition in _definitions.values():
+	for def in _definitions.values():
 		if def.repeatable or not _instances.has(def.id):
 			pool.append({"def": def, "weight": def.weight})
 	return pool

--- a/ability/pick_ui/ability_card.gd
+++ b/ability/pick_ui/ability_card.gd
@@ -25,7 +25,7 @@ func _gui_input(event: InputEvent) -> void:
 		_select()
 
 
-func setup(def: AbilityDefinition) -> void:
+func setup(def) -> void:
 	_ability_id = def.id
 	name_label.text = def.display_name
 	rarity_label.text = "【%s】" % def.rarity_label()

--- a/ability/pick_ui/ability_card.gd
+++ b/ability/pick_ui/ability_card.gd
@@ -25,7 +25,7 @@ func _gui_input(event: InputEvent) -> void:
 		_select()
 
 
-func setup(def) -> void:
+func setup(def: AbilityDefinition) -> void:
 	_ability_id = def.id
 	name_label.text = def.display_name
 	rarity_label.text = "【%s】" % def.rarity_label()

--- a/ability/synergy_resolver.gd
+++ b/ability/synergy_resolver.gd
@@ -3,6 +3,8 @@
 class_name SynergyResolver
 extends RefCounted
 
+const ModifierPipeline = preload("res://ability/modifier_pipeline.gd")
+
 const CONFIG_PATH := "res://ability/synergies_config.json"
 
 var _synergy_defs: Array = []


### PR DESCRIPTION
## 问题

游戏在 Godot 4.6 下编译失败，核心原因是 GDScript 的 `class_name` 自引用类型问题：

1. `ability_definition.gd` 的 `static func from_dict() -> AbilityDefinition` 中，GDScript 无法解析同一个 `class_name` 作为静态方法的返回类型
2. 这导致 `ability_instance.gd`、`ability_manager.gd`、`ability_card.gd` 等下游文件连锁编译失败
3. `AbilityManager` autoload 无法实例化，游戏完全无法运行

## 修复

### `ability/ability_definition.gd`
- `from_dict` 从 `static` 改为实例方法，完全消除 `class_name` 自引用问题

### `ability/ability_instance.gd`
- 移除 `definition: AbilityDefinition` 类型注解（避免下游连锁失败）

### `ability/ability_manager.gd`
- 移除 `var def: AbilityDefinition`、`func(d: AbilityDefinition)` 等类型注解
- `AbilityDefinition.from_dict(entry)` → `AbilityDefinition.new(); .from_dict(entry)`

### `ability/synergy_resolver.gd`
- 添加 `const ModifierPipeline = preload(...)`（之前只依赖 `class_name`，可能存在编译顺序问题）

## 验证

- `godot --headless --quit` 编译通过，零 SCRIPT ERROR
- 仅剩的 4 个 `Parse Error` 均为图片资源 `.godot/imported/` 缓存缺失，非代码问题