### PR TITLE
feat(ability): 拆分能力描述为效果/世界观两项，卡片双样式展示

### DIFF
--- a/ability/abilities_config.json
+++ b/ability/abilities_config.json
@@ -3,7 +3,8 @@
     {
       "id": "speed_boost",
       "name": "惶惶",
-      "description": "发作时的不安驱你更快地躲避。那些迫近的，你不能让它们靠近。",
+      "description": "移动速度大幅提升",
+      "narrative": "发作时的不安驱你更快地躲避。那些迫近的，你不能让它们靠近。",
       "rarity": 1,
       "weight": 100,
       "max_level": 1,
@@ -16,7 +17,8 @@
     {
       "id": "shield_reflect",
       "name": "盾反",
-      "description": "他们递来的东西，你有时候抓不住。但你会推开。推开的那些，也许正是最需要接住的。",
+      "description": "格挡时有概率反弹弹幕",
+      "narrative": "他们递来的东西，你有时候抓不住。但你会推开。推开的那些，也许正是最需要接住的。",
       "rarity": 2,
       "weight": 80,
       "max_level": 1,
@@ -29,7 +31,8 @@
     {
       "id": "counter_spiral",
       "name": "反击螺旋",
-      "description": "格挡时有概率让护盾短时间高速旋转。",
+      "description": "格挡时概率触发，护盾短时间高速旋转",
+      "narrative": "失序有时也是一种防御。当周围的一切都开始旋转，你反而觉得自己稳住了。",
       "rarity": 2,
       "weight": 70,
       "max_level": 1,
@@ -46,7 +49,8 @@
     {
       "id": "health_regen",
       "name": "生命恢复",
-      "description": "照护不会停止。即使你不开口，那些声音也会在你里面继续起作用——一点一点地修复着什么。",
+      "description": "每隔一段时间自动恢复生命值",
+      "narrative": "照护不会停止。即使你不开口，那些声音也会在你里面继续起作用——一点一点地修复着什么。",
       "rarity": 1,
       "weight": 90,
       "max_level": 1,
@@ -60,7 +64,8 @@
     {
       "id": "crit_block",
       "name": "残片",
-      "description": "每次格挡，你都抓住了一些正在流失的东西——一块记忆的残片，一段你暂时还能说出的名字。",
+      "description": "格挡时有几率获得更多经验值",
+      "narrative": "每次格挡，你都抓住了一些正在流失的东西——一块记忆的残片，一段你暂时还能说出的名字。",
       "rarity": 2,
       "weight": 70,
       "max_level": 1,
@@ -74,7 +79,8 @@
     {
       "id": "max_health_up",
       "name": "稳固边界",
-      "description": "你要坚守的那些部分，今天似乎更坚固了一点。能多撑一会了。",
+      "description": "生命上限提升",
+      "narrative": "你要坚守的那些部分，今天似乎更坚固了一点。能多撑一会了。",
       "rarity": 2,
       "weight": 65,
       "max_level": 1,
@@ -88,7 +94,8 @@
     {
       "id": "breathing_orbit",
       "name": "呼吸摆盾",
-      "description": "儿子的守护像呼吸一样有节奏，时而贴近，时而留出缝隙。但从未离开。",
+      "description": "护盾环绕半径周期性变化，时而贴近，时而远离",
+      "narrative": "儿子的守护像呼吸一样有节奏，时而贴近，时而留出缝隙。但从未离开。",
       "rarity": 2,
       "weight": 75,
       "max_level": 1,

--- a/ability/ability_definition.gd
+++ b/ability/ability_definition.gd
@@ -6,6 +6,7 @@ extends RefCounted
 var id: String = ""
 var display_name: String = ""
 var description: String = ""
+var narrative: String = ""
 var rarity: int = 1          # 1=普通 2=稀有 3=史诗
 var weight: int = 100        # 候选池权重
 var max_level: int = 1
@@ -18,6 +19,7 @@ func from_dict(data: Dictionary) -> void:
 	id = data.get("id", "")
 	display_name = data.get("name", "")
 	description = data.get("description", "")
+	narrative = data.get("narrative", "")
 	rarity = data.get("rarity", 1)
 	weight = data.get("weight", 100)
 	max_level = data.get("max_level", 1)

--- a/ability/pick_ui/ability_card.gd
+++ b/ability/pick_ui/ability_card.gd
@@ -8,7 +8,7 @@ signal card_selected(ability_id: String)
 @onready var name_label: Label = $VBoxContainer/name_label
 @onready var rarity_label: Label = $VBoxContainer/rarity_label
 @onready var desc_label: Label = $VBoxContainer/desc_label
-@onready var narrative_label: Label = $VBoxContainer/narrative_label
+@onready var narrative_label: RichTextLabel = $VBoxContainer/narrative_label
 @onready var level_label: Label = $VBoxContainer/level_label
 
 var _ability_id: String = ""
@@ -31,7 +31,7 @@ func setup(def: AbilityDefinition) -> void:
 	name_label.text = def.display_name
 	rarity_label.text = "【%s】" % def.rarity_label()
 	desc_label.text = def.description
-	narrative_label.text = def.narrative
+	narrative_label.text = "[i]%s[/i]" % def.narrative
 	level_label.text = "可重复获得" if def.repeatable else "唯一能力（不可升级）"
 
 	# 根据稀有度设置卡片颜色

--- a/ability/pick_ui/ability_card.gd
+++ b/ability/pick_ui/ability_card.gd
@@ -8,6 +8,7 @@ signal card_selected(ability_id: String)
 @onready var name_label: Label = $VBoxContainer/name_label
 @onready var rarity_label: Label = $VBoxContainer/rarity_label
 @onready var desc_label: Label = $VBoxContainer/desc_label
+@onready var narrative_label: Label = $VBoxContainer/narrative_label
 @onready var level_label: Label = $VBoxContainer/level_label
 
 var _ability_id: String = ""
@@ -30,6 +31,7 @@ func setup(def: AbilityDefinition) -> void:
 	name_label.text = def.display_name
 	rarity_label.text = "【%s】" % def.rarity_label()
 	desc_label.text = def.description
+	narrative_label.text = def.narrative
 	level_label.text = "可重复获得" if def.repeatable else "唯一能力（不可升级）"
 
 	# 根据稀有度设置卡片颜色

--- a/ability/pick_ui/ability_card.tscn
+++ b/ability/pick_ui/ability_card.tscn
@@ -41,6 +41,16 @@ autowrap_mode = 3
 mouse_filter = 2
 theme_override_font_sizes/font_size = 14
 
+[node name="narrative_label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "世界观描述"
+autowrap_mode = 3
+mouse_filter = 2
+theme_override_colors/font_color = Color(0.69, 0.69, 0.69, 1)
+theme_override_font_sizes/font_size = 13
+theme_override_constants/margin_top = 8
+
 [node name="level_label" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 text = "新能力"

--- a/ability/pick_ui/ability_card.tscn
+++ b/ability/pick_ui/ability_card.tscn
@@ -41,15 +41,20 @@ autowrap_mode = 3
 mouse_filter = 2
 theme_override_font_sizes/font_size = 14
 
-[node name="narrative_label" type="Label" parent="VBoxContainer"]
+[node name="narrative_spacer" type="Control" parent="VBoxContainer"]
 layout_mode = 2
-size_flags_vertical = 3
-text = "世界观描述"
-autowrap_mode = 3
+custom_minimum_size = Vector2(0, 8)
 mouse_filter = 2
-theme_override_colors/font_color = Color(0.69, 0.69, 0.69, 1)
-theme_override_font_sizes/font_size = 13
-theme_override_constants/margin_top = 8
+
+[node name="narrative_label" type="RichTextLabel" parent="VBoxContainer"]
+layout_mode = 2
+fit_content = true
+bbcode_enabled = true
+text = "[i]世界观描述[/i]"
+scroll_active = false
+mouse_filter = 2
+theme_override_colors/default_color = Color(0.69, 0.69, 0.69, 1)
+theme_override_font_sizes/normal_font_size = 13
 
 [node name="level_label" type="Label" parent="VBoxContainer"]
 layout_mode = 2


### PR DESCRIPTION
将能力的单条 `description` 拆分为两条描述：

- **`description`** — 效果/机制描述（如："移动速度大幅提升"）
- **`narrative`** — 世界观对齐描述（如："发作时的不安驱你更快地躲避..."）

### 修改文件
| 文件 | 变更 |
|---|---|
| `ability/abilities_config.json` | 7 个能力拆分为 description + narrative |
| `ability/ability_definition.gd` | 新增 `narrative` 字段及解析 |
| `ability/pick_ui/ability_card.tscn` | 新增 `narrative_label` 节点（灰色样式） |
| `ability/pick_ui/ability_card.gd` | 绑定并赋值双描述标签 |

### UI 样式
- 效果描述：白色正文，14px
- 世界观描述：灰色（#B0B0B0）斜体，13px，8px 上间距

### 测试建议
- 触发升级三选一，确认每张卡片显示两条描述
- 确认样式区分正常