### PR TITLE
feat: 选能力后屏幕中央浮字提示「获得【能力名】」

### DIFF
--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -118,6 +118,11 @@ func select_ability(ability_id: String) -> void:
 
 # ─── 查询 ─────────────────────────────────────────────────────────────────────
 
+## 根据能力 ID 返回显示名（用于 UI 反馈）
+func get_ability_name(ability_id: String) -> String:
+	var def = _definitions.get(ability_id, null)
+	return def.display_name if def else ability_id
+
 func get_instance(ability_id: String) -> AbilityInstance:
 	return _instances.get(ability_id, null)
 

--- a/ability/feedback/ability_feedback.gd
+++ b/ability/feedback/ability_feedback.gd
@@ -1,0 +1,43 @@
+# 选能力后屏幕中央浮字提示「获得【能力名】」。
+# 使用 CanvasLayer 放置在最上层，不打断战斗操作。
+extends CanvasLayer
+
+@onready var feedback_label: Label = $FeedbackLabel
+var _tween: Tween = null
+
+
+func _ready() -> void:
+	layer = 200
+	feedback_label.hide()
+	# 监听能力获取信号
+	AbilityManager.ability_acquired.connect(_on_ability_acquired)
+
+
+func _on_ability_acquired(ability_id: String, _level: int) -> void:
+	var ability_name := AbilityManager.get_ability_name(ability_id)
+	feedback_label.text = "获得【%s】" % ability_name
+	feedback_label.modulate = Color(1, 1, 1, 0)
+	feedback_label.show()
+
+	if _tween != null:
+		_tween.kill()
+
+	# 动画时序：淡入 0.1s → 停留 0.5s → 淡出 0.2s
+	_tween = create_tween().set_parallel(false)
+	# 淡入
+	_tween.tween_property(feedback_label, "modulate", Color(1, 1, 1, 1), 0.1)\
+		.set_ease(Tween.EASE_IN)
+	# 停留
+	_tween.tween_interval(0.5)
+	# 淡出
+	_tween.tween_property(feedback_label, "modulate", Color(1, 1, 1, 0), 0.2)\
+		.set_ease(Tween.EASE_OUT)
+	_tween.finished.connect(_on_feedback_done.bind(_tween), CONNECT_ONE_SHOT)
+
+
+func _on_feedback_done(t: Tween) -> void:
+	if t != _tween:
+		return
+	# 仅当已经完全淡出才隐藏，防止被新 tween 覆盖时误隐藏
+	if feedback_label.modulate.a <= 0.01:
+		feedback_label.hide()

--- a/ability/feedback/ability_feedback.gd.uid
+++ b/ability/feedback/ability_feedback.gd.uid
@@ -1,0 +1,2 @@
+uid://abilityfeedbackgd001
+

--- a/ability/feedback/ability_feedback.gd.uid
+++ b/ability/feedback/ability_feedback.gd.uid
@@ -1,2 +1,1 @@
-uid://abilityfeedbackgd001
-
+uid://dsp05ug3v0yna

--- a/ability/feedback/ability_feedback.tscn
+++ b/ability/feedback/ability_feedback.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=2 format=3 uid="uid://abilityfeedback001"]
+
+[ext_resource type="Script" path="res://ability/feedback/ability_feedback.gd" id="1_feedback_script"]
+
+[node name="ability_feedback" type="CanvasLayer"]
+layer = 200
+script = ExtResource("1_feedback_script")
+
+[node name="FeedbackLabel" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -24.0
+offset_right = 200.0
+offset_bottom = 24.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 32
+horizontal_alignment = 1
+vertical_alignment = 1
+text = ""

--- a/main.tscn
+++ b/main.tscn
@@ -16,6 +16,7 @@
 [ext_resource type="PackedScene" uid="uid://bombuibase001" path="res://bomb/bomb_ui.tscn" id="13_bomb_ui"]
 [ext_resource type="PackedScene" uid="uid://versionlabel001" path="res://start/version_label.tscn" id="14_version_label"]
 [ext_resource type="PackedScene" uid="uid://xaji0y6dpbhsah" path="res://pause/pause_ui.tscn" id="15_pause_ui"]
+[ext_resource type="PackedScene" uid="uid://abilityfeedback001" path="res://ability/feedback/ability_feedback.tscn" id="16_ability_feedback"]
 
 [node name="main" type="Node2D" unique_id=1686072544]
 
@@ -61,3 +62,5 @@ z_index = 101
 texture = ExtResource("7_joystick_knob")
 
 [node name="pause_ui" parent="." instance=ExtResource("15_pause_ui")]
+
+[node name="ability_feedback" parent="." instance=ExtResource("16_ability_feedback")]


### PR DESCRIPTION
## 改动内容

实现 #38 — 每次选能力后在屏幕中央显示浮字提示，给玩家即时确认感。

### 新增文件
- **ability/feedback/ability_feedback.gd** — CanvasLayer 浮字组件，监听 AbilityManager.ability_acquired 信号
- **ability/feedback/ability_feedback.tscn** — 场景文件，标签居中于屏幕

### 修改文件
- **ability/ability_manager.gd** — 添加 get_ability_name() 公共方法
- **main.tscn** — 实例化 ability_feedback 场景

## 动画时序
淡入 0.1s → 停留 0.5s → 淡出 0.2s（总计 0.8s）

## 验收
1. ✅ 每次选能力后 ~0.8s 内看到"获得【能力名】"文字提示
2. ✅ CanvasLayer layer=200，不打断战斗操作（可继续移动/格挡）
3. ✅ 连续触发（repeatable 能力）时 kill 旧 tween 直接覆盖新文字，不叠加干扰
4. ✅ godot --headless 语法验证通过

Closes #38