### PR TITLE
feat: 暂停界面添加 GM 按钮和直接获取能力功能

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -44,6 +44,7 @@ jobs:
     outputs:
       pr_number:   ${{ steps.meta.outputs.pr_number }}
       preview_url: ${{ steps.meta.outputs.preview_url }}
+      version:     ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -75,6 +76,14 @@ jobs:
           godot-version: ${{ env.GODOT_VERSION }}
           godot-template-version: ${{ env.GODOT_TEMPLATE_VERSION }}
           output-dir: build/web
+
+      - name: Read version from patched version.gd
+        id: version
+        run: |
+          set -euo pipefail
+          MAJOR=$(grep -oP '(?<=const MAJOR_VERSION: String = ")[^"]+' version.gd)
+          BUILD=$(grep -oP '(?<=const BUILD_NUMBER: int = )\d+' version.gd)
+          echo "version=v${MAJOR}.${BUILD}" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -159,50 +168,35 @@ jobs:
           PR_NUMBER:   ${{ needs.build-preview.outputs.pr_number }}
           HEAD_SHA:    ${{ github.event.pull_request.head.sha }}
           HEAD_REF:    ${{ github.event.pull_request.head.ref }}
+          VERSION:     ${{ needs.build-preview.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const marker = '<!-- shield-core-pr-preview -->';
-            const url    = process.env.PREVIEW_URL;
-            const sha    = process.env.HEAD_SHA;
-            const ref    = process.env.HEAD_REF;
-            const prNum  = Number(process.env.PR_NUMBER);
+            const marker  = '<!-- shield-core-pr-preview -->';
+            const url     = process.env.PREVIEW_URL;
+            const sha     = process.env.HEAD_SHA;
+            const ref     = process.env.HEAD_REF;
+            const version = process.env.VERSION;
+            const prNum   = Number(process.env.PR_NUMBER);
             const body = [
               marker,
               '### 🕹️ PR 预览构建完成',
               '',
               `- 测试地址: ${url}`,
+              `- 版本: ${version}`,
               `- 分支: \`${ref}\``,
               `- 提交: \`${sha.slice(0, 7)}\``,
               '',
               'GitHub Pages CDN 缓存可能需要 1–2 分钟刷新。确认无误后再点击合并即可。',
             ].join('\n');
 
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                issue_number: prNum,
-                per_page: 100,
-              }
-            );
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                issue_number: prNum,
-                body,
-              });
-            }
+            // Always create a new comment so every commit gets its own reply.
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: prNum,
+              body,
+            });
 
   cleanup-preview:
     name: Cleanup preview on close

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -178,6 +178,24 @@ jobs:
             const ref     = process.env.HEAD_REF;
             const version = process.env.VERSION;
             const prNum   = Number(process.env.PR_NUMBER);
+
+            // Fetch the commit message from the API for a human-readable description.
+            let commitMsg = '';
+            try {
+              const commit = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                ref:   sha,
+              });
+              commitMsg = commit.data.commit.message.split('\n')[0];
+            } catch (_) {
+              commitMsg = sha.slice(0, 7);
+            }
+
+            const shaLine = commitMsg
+              ? `- 提交: \`${sha.slice(0, 7)}\` — ${commitMsg}`
+              : `- 提交: \`${sha.slice(0, 7)}\``;
+
             const body = [
               marker,
               '### 🕹️ PR 预览构建完成',
@@ -185,7 +203,7 @@ jobs:
               `- 测试地址: ${url}`,
               `- 版本: ${version}`,
               `- 分支: \`${ref}\``,
-              `- 提交: \`${sha.slice(0, 7)}\``,
+              shaLine,
               '',
               'GitHub Pages CDN 缓存可能需要 1–2 分钟刷新。确认无误后再点击合并即可。',
             ].join('\n');

--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -128,8 +128,11 @@ func get_ability_definition(ability_id: String) -> AbilityDefinition:
 	return _definitions.get(ability_id, null)
 
 
-func get_all_definition_ids() -> Array:
-	return _definitions.keys()
+func get_all_definition_ids() -> Array[String]:
+	var ability_ids: Array[String] = []
+	for ability_id in _definitions.keys():
+		ability_ids.append(String(ability_id))
+	return ability_ids
 
 
 func get_instance(ability_id: String) -> AbilityInstance:

--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -125,8 +125,7 @@ func get_ability_name(ability_id: String) -> String:
 
 
 func get_ability_definition(ability_id: String) -> AbilityDefinition:
-	var def: AbilityDefinition = _definitions.get(ability_id, null)
-	return def
+	return _definitions.get(ability_id, null)
 
 
 func get_all_definition_ids() -> Array:

--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -123,6 +123,16 @@ func get_ability_name(ability_id: String) -> String:
 	var def = _definitions.get(ability_id, null)
 	return def.display_name if def else ability_id
 
+
+func get_ability_definition(ability_id: String) -> AbilityDefinition:
+	var def: AbilityDefinition = _definitions.get(ability_id, null)
+	return def
+
+
+func get_all_definition_ids() -> Array:
+	return _definitions.keys()
+
+
 func get_instance(ability_id: String) -> AbilityInstance:
 	return _instances.get(ability_id, null)
 

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -67,12 +67,13 @@ func _build_ability_list() -> void:
 		child.queue_free()
 
 	# 从 AbilityManager 读取所有能力定义
-	var ability_ids: Array = AbilityManager.get_all_definition_ids()
+	var ability_ids: Array[String] = AbilityManager.get_all_definition_ids()
 	ability_ids.sort()
 
 	for ability_id in ability_ids:
 		var def: AbilityDefinition = AbilityManager.get_ability_definition(ability_id)
 		if def == null:
+			push_warning("[PauseUI] 跳过无效能力定义: %s" % ability_id)
 			continue
 		var btn := Button.new()
 		btn.text = "%s\n%s" % [def.display_name, def.description]

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -13,6 +13,7 @@ const GM_ABILITY_BUTTON_MIN_SIZE := Vector2(360, 72)
 @onready var gm_button: Button = %gm_button
 @onready var gm_panel: CenterContainer = %gm_panel
 @onready var gm_back_button: Button = %gm_back_button
+@onready var gm_scroll: ScrollContainer = %gm_scroll
 @onready var gm_ability_list: VBoxContainer = %gm_ability_list
 
 var _ability_list_built: bool = false
@@ -25,6 +26,26 @@ func _ready() -> void:
 	gm_button.pressed.connect(_on_gm_pressed)
 	gm_back_button.pressed.connect(_on_gm_back_pressed)
 	pause_overlay.hide()
+
+	# 加宽 GM 能力列表的滑块，方便拖拽
+	var v_bar := gm_scroll.get_v_scroll_bar()
+	if v_bar == null:
+		return
+	v_bar.add_theme_constant_override("scrollbar_width", 16)
+	var grabber := StyleBoxFlat.new()
+	grabber.bg_color = Color(0.6, 0.6, 0.65, 0.85)
+	grabber.corner_radius_top_left = 4
+	grabber.corner_radius_top_right = 4
+	grabber.corner_radius_bottom_right = 4
+	grabber.corner_radius_bottom_left = 4
+	v_bar.add_theme_stylebox_override("grabber", grabber)
+	var grabber_hover := StyleBoxFlat.new()
+	grabber_hover.bg_color = Color(0.75, 0.75, 0.85, 1.0)
+	grabber_hover.corner_radius_top_left = 4
+	grabber_hover.corner_radius_top_right = 4
+	grabber_hover.corner_radius_bottom_right = 4
+	grabber_hover.corner_radius_bottom_left = 4
+	v_bar.add_theme_stylebox_override("grabber_highlight", grabber_hover)
 
 
 func _on_pause_pressed() -> void:

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -1,16 +1,28 @@
 # 暂停按钮 + 暂停覆盖界面
 # 右上角悬浮按钮，点击后暂停游戏并显示暂停菜单
+# GM 模式：从暂停界面进入，直接获取任意能力
 extends CanvasLayer
+
+const AbilityDefinition = preload("res://ability/ability_definition.gd")
 
 @onready var pause_button: Button = %pause_button
 @onready var pause_overlay: ColorRect = %pause_overlay
 @onready var resume_button: Button = %resume_button
+@onready var pause_menu_vbox: VBoxContainer = %VBox
+@onready var gm_button: Button = %gm_button
+@onready var gm_panel: CenterContainer = %gm_panel
+@onready var gm_back_button: Button = %gm_back_button
+@onready var gm_ability_list: VBoxContainer = %gm_ability_list
+
+var _ability_list_built: bool = false
 
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	pause_button.pressed.connect(_on_pause_pressed)
 	resume_button.pressed.connect(_on_resume_pressed)
+	gm_button.pressed.connect(_on_gm_pressed)
+	gm_back_button.pressed.connect(_on_gm_back_pressed)
 	pause_overlay.hide()
 
 
@@ -21,6 +33,78 @@ func _on_pause_pressed() -> void:
 
 
 func _on_resume_pressed() -> void:
+	_close_pause()
+
+
+func _on_gm_pressed() -> void:
+	if not _ability_list_built:
+		_build_ability_list()
+		_ability_list_built = true
+	pause_menu_vbox.hide()
+	gm_panel.show()
+
+
+func _on_gm_back_pressed() -> void:
+	gm_panel.hide()
+	pause_menu_vbox.show()
+
+
+func _on_gm_ability_selected(ability_id: String) -> void:
+	AbilityManager.select_ability(ability_id)
+	_close_pause()
+
+
+func _close_pause() -> void:
 	get_tree().paused = false
 	pause_overlay.hide()
 	pause_button.show()
+
+
+func _build_ability_list() -> void:
+	# 清空旧内容
+	for child in gm_ability_list.get_children():
+		child.queue_free()
+
+	# 从 AbilityManager 读取所有能力定义
+	var ability_ids := AbilityManager._definitions.keys()
+	ability_ids.sort()
+
+	for id in ability_ids:
+		var def: AbilityDefinition = AbilityManager._definitions[id]
+		var btn := Button.new()
+		btn.text = "%s\n[size=14]%s[/size]" % [def.display_name, def.description]
+		btn.flat = false
+		btn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		btn.custom_minimum_size = Vector2(360, 60)
+		btn.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+
+		# 样式
+		var theme_normal := StyleBoxFlat.new()
+		theme_normal.bg_color = Color(0.25, 0.25, 0.3, 0.8)
+		theme_normal.corner_radius_top_left = 6
+		theme_normal.corner_radius_top_right = 6
+		theme_normal.corner_radius_bottom_right = 6
+		theme_normal.corner_radius_bottom_left = 6
+
+		var theme_hover := StyleBoxFlat.new()
+		theme_hover.bg_color = Color(0.35, 0.35, 0.45, 0.85)
+		theme_hover.corner_radius_top_left = 6
+		theme_hover.corner_radius_top_right = 6
+		theme_hover.corner_radius_bottom_right = 6
+		theme_hover.corner_radius_bottom_left = 6
+
+		btn.add_theme_stylebox_override("normal", theme_normal)
+		btn.add_theme_stylebox_override("hover", theme_hover)
+		btn.add_theme_stylebox_override("pressed", theme_hover)
+
+		btn.add_theme_color_override("font_color", Color(1, 1, 1, 1))
+
+		# 允许使用 BBCode 显示大小不同的文字
+		btn.bbcode_enabled = true
+
+		var captured_id: String = id
+		btn.pressed.connect(func():
+			_on_gm_ability_selected(captured_id)
+		)
+
+		gm_ability_list.add_child(btn)

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -25,6 +25,7 @@ func _ready() -> void:
 	gm_button.pressed.connect(_on_gm_pressed)
 	gm_back_button.pressed.connect(_on_gm_back_pressed)
 	pause_overlay.hide()
+	gm_ability_list.mouse_filter = Control.MOUSE_FILTER_PASS
 
 
 func _on_pause_pressed() -> void:

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -4,6 +4,7 @@
 extends CanvasLayer
 
 const AbilityDefinition = preload("res://ability/ability_definition.gd")
+const GM_ABILITY_BUTTON_MIN_SIZE := Vector2(360, 72)
 
 @onready var pause_button: Button = %pause_button
 @onready var pause_overlay: ColorRect = %pause_overlay
@@ -69,8 +70,7 @@ func _build_ability_list() -> void:
 	var ability_ids: Array = AbilityManager.get_all_definition_ids()
 	ability_ids.sort()
 
-	for ability_id_variant in ability_ids:
-		var ability_id := String(ability_id_variant)
+	for ability_id in ability_ids:
 		var def: AbilityDefinition = AbilityManager.get_ability_definition(ability_id)
 		if def == null:
 			continue
@@ -78,7 +78,7 @@ func _build_ability_list() -> void:
 		btn.text = "%s\n%s" % [def.display_name, def.description]
 		btn.flat = false
 		btn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		btn.custom_minimum_size = Vector2(360, 72)
+		btn.custom_minimum_size = GM_ABILITY_BUTTON_MIN_SIZE
 		btn.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 		btn.tooltip_text = def.description
 

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -8,7 +8,7 @@ const AbilityDefinition = preload("res://ability/ability_definition.gd")
 @onready var pause_button: Button = %pause_button
 @onready var pause_overlay: ColorRect = %pause_overlay
 @onready var resume_button: Button = %resume_button
-@onready var pause_menu_vbox: VBoxContainer = %VBox
+@onready var pause_menu_vbox: VBoxContainer = %PauseMenuVBox
 @onready var gm_button: Button = %gm_button
 @onready var gm_panel: CenterContainer = %gm_panel
 @onready var gm_back_button: Button = %gm_back_button
@@ -66,17 +66,21 @@ func _build_ability_list() -> void:
 		child.queue_free()
 
 	# 从 AbilityManager 读取所有能力定义
-	var ability_ids := AbilityManager._definitions.keys()
+	var ability_ids: Array = AbilityManager.get_all_definition_ids()
 	ability_ids.sort()
 
-	for id in ability_ids:
-		var def: AbilityDefinition = AbilityManager._definitions[id]
+	for ability_id_variant in ability_ids:
+		var ability_id := String(ability_id_variant)
+		var def: AbilityDefinition = AbilityManager.get_ability_definition(ability_id)
+		if def == null:
+			continue
 		var btn := Button.new()
-		btn.text = "%s\n[size=14]%s[/size]" % [def.display_name, def.description]
+		btn.text = "%s\n%s" % [def.display_name, def.description]
 		btn.flat = false
 		btn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		btn.custom_minimum_size = Vector2(360, 60)
+		btn.custom_minimum_size = Vector2(360, 72)
 		btn.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+		btn.tooltip_text = def.description
 
 		# 样式
 		var theme_normal := StyleBoxFlat.new()
@@ -99,10 +103,7 @@ func _build_ability_list() -> void:
 
 		btn.add_theme_color_override("font_color", Color(1, 1, 1, 1))
 
-		# 允许使用 BBCode 显示大小不同的文字
-		btn.bbcode_enabled = true
-
-		var captured_id: String = id
+		var captured_id: String = ability_id
 		btn.pressed.connect(func():
 			_on_gm_ability_selected(captured_id)
 		)

--- a/pause/pause_ui.gd
+++ b/pause/pause_ui.gd
@@ -25,7 +25,6 @@ func _ready() -> void:
 	gm_button.pressed.connect(_on_gm_pressed)
 	gm_back_button.pressed.connect(_on_gm_back_pressed)
 	pause_overlay.hide()
-	gm_ability_list.mouse_filter = Control.MOUSE_FILTER_PASS
 
 
 func _on_pause_pressed() -> void:

--- a/pause/pause_ui.tscn
+++ b/pause/pause_ui.tscn
@@ -93,19 +93,19 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="VBox" type="VBoxContainer" parent="pause_overlay/CenterContainer"]
+[node name="PauseMenuVBox" type="VBoxContainer" parent="pause_overlay/CenterContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 24
 
-[node name="title" type="Label" parent="pause_overlay/CenterContainer/VBox"]
+[node name="title" type="Label" parent="pause_overlay/CenterContainer/PauseMenuVBox"]
 layout_mode = 2
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 48
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 text = "PAUSED"
 
-[node name="resume_button" type="Button" parent="pause_overlay/CenterContainer/VBox"]
+[node name="resume_button" type="Button" parent="pause_overlay/CenterContainer/PauseMenuVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 custom_minimum_size = Vector2(200, 50)
@@ -116,7 +116,7 @@ theme_override_font_sizes/font_size = 20
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 text = "▶ 继续游戏"
 
-[node name="gm_button" type="Button" parent="pause_overlay/CenterContainer/VBox"]
+[node name="gm_button" type="Button" parent="pause_overlay/CenterContainer/PauseMenuVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 custom_minimum_size = Vector2(200, 50)

--- a/pause/pause_ui.tscn
+++ b/pause/pause_ui.tscn
@@ -23,6 +23,34 @@ corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gm"]
+bg_color = Color(0.7, 0.3, 0.3, 0.8)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_gm_hover"]
+bg_color = Color(0.85, 0.4, 0.4, 0.85)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ability_item"]
+bg_color = Color(0.25, 0.25, 0.3, 0.8)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ability_item_hover"]
+bg_color = Color(0.35, 0.35, 0.45, 0.85)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
 [node name="PauseUI" type="CanvasLayer"]
 layer = 200
 script = ExtResource("1_script")
@@ -66,6 +94,7 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="VBox" type="VBoxContainer" parent="pause_overlay/CenterContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 24
 
@@ -86,3 +115,65 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_resume")
 theme_override_font_sizes/font_size = 20
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 text = "▶ 继续游戏"
+
+[node name="gm_button" type="Button" parent="pause_overlay/CenterContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 50)
+theme_override_styles/normal = SubResource("StyleBoxFlat_gm")
+theme_override_styles/hover = SubResource("StyleBoxFlat_gm_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_gm_hover")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+text = "GM 模式"
+
+[node name="gm_panel" type="CenterContainer" parent="pause_overlay"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="VBox" type="VBoxContainer" parent="pause_overlay/gm_panel"]
+layout_mode = 2
+custom_minimum_size = Vector2(400, 0)
+theme_override_constants/separation = 12
+
+[node name="gm_title" type="Label" parent="pause_overlay/gm_panel/VBox"]
+layout_mode = 2
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(1, 0.4, 0.4, 1)
+text = "GM 模式"
+
+[node name="subtitle" type="Label" parent="pause_overlay/gm_panel/VBox"]
+layout_mode = 2
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 16
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+text = "直接获取能力"
+
+[node name="gm_scroll" type="ScrollContainer" parent="pause_overlay/gm_panel/VBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 300)
+
+[node name="gm_ability_list" type="VBoxContainer" parent="pause_overlay/gm_panel/VBox/gm_scroll"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="gm_back_button" type="Button" parent="pause_overlay/gm_panel/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+custom_minimum_size = Vector2(200, 40)
+theme_override_font_sizes/font_size = 18
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+text = "← 返回"

--- a/pause/pause_ui.tscn
+++ b/pause/pause_ui.tscn
@@ -164,12 +164,10 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_minimum_size = Vector2(0, 300)
-scroll_vertical_enabled = true
 
 [node name="gm_ability_list" type="VBoxContainer" parent="pause_overlay/gm_panel/VBox/gm_scroll"]
 unique_name_in_owner = true
 layout_mode = 2
-mouse_filter = 1
 theme_override_constants/separation = 8
 
 [node name="gm_back_button" type="Button" parent="pause_overlay/gm_panel/VBox"]

--- a/pause/pause_ui.tscn
+++ b/pause/pause_ui.tscn
@@ -160,6 +160,7 @@ theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
 text = "直接获取能力"
 
 [node name="gm_scroll" type="ScrollContainer" parent="pause_overlay/gm_panel/VBox"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/pause/pause_ui.tscn
+++ b/pause/pause_ui.tscn
@@ -164,10 +164,12 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_minimum_size = Vector2(0, 300)
+scroll_vertical_enabled = true
 
 [node name="gm_ability_list" type="VBoxContainer" parent="pause_overlay/gm_panel/VBox/gm_scroll"]
 unique_name_in_owner = true
 layout_mode = 2
+mouse_filter = 1
 theme_override_constants/separation = 8
 
 [node name="gm_back_button" type="Button" parent="pause_overlay/gm_panel/VBox"]


### PR DESCRIPTION
## 概述

在暂停界面添加了一个 GM 按钮，点击后可进入 GM 界面直接获取任意能力，用于调试和测试。

### 改动文件

- **pause/pause_ui.tscn** — 新增 GM 按钮、GM 面板（CenterContainer + ScrollContainer + 能力按钮列表容器 + 返回按钮）
- **pause/pause_ui.gd** — 新增 GM 面板显示/隐藏逻辑、动态生成能力按钮列表、调用 select_ability

### 功能说明

1. 暂停菜单中新增红色「GM 模式」按钮（位于「继续游戏」下方）
2. 点击进入 GM 界面，展示滑动列表，读取 abilities_config.json 中所有能力
3. 每个能力按钮显示名称 + 描述
4. 点击能力按钮 → 调用 `AbilityManager.select_ability()`（与升级三选一界面相同的方法）
5. 选中后自动关闭 GM 面板和暂停界面，恢复游戏
6. 「← 返回」按钮可回到暂停菜单

### 测试方式

1. 运行游戏
2. 点击右上角 ⏸ 暂停
3. 点击「GM 模式」
4. 选择任意能力
5. 验证：暂停界面关闭，游戏继续，能力已生效