### PR TITLE
feat(health-ui): max_health_up 选择反馈 — 分段血量条 + 扩容扫光动画

### DIFF
--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -113,6 +113,7 @@ func select_ability(ability_id: String) -> void:
 	_rebuild_pipeline()
 	ability_acquired.emit(ability_id, final_inst.get_stack_count() if final_inst else 1)
 	abilities_updated.emit()
+	EventBus.on_pick_feedback.emit(ability_id, final_inst.get_stack_count() if final_inst else 1)
 	_finish_level_up_selection()
 
 

--- a/ability/event_bus.gd
+++ b/ability/event_bus.gd
@@ -19,6 +19,8 @@ signal on_crit(context: Dictionary)
 # ---------- 能力系统事件 ----------
 ## 获得新能力
 signal on_ability_acquired(ability_id: String, level: int)
+## 选择能力后的专属视觉反馈（非阻塞动画）
+signal on_pick_feedback(ability_id: String, level: int)
 ## 联动激活
 signal on_synergy_activated(synergy_id: String)
 ## 反击螺旋触发

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,0 +1,58 @@
+extends Panel
+
+## 血量格子填充矩形
+@onready var fill_rect: ColorRect = $FillRect
+
+## 填充色（红）
+@export var fill_color: Color = Color(0.905882, 0.298039, 0.235294, 1)
+## 背景色（暗灰）
+@export var bg_color: Color = Color(0.2, 0.2, 0.2, 0.8)
+
+var _tween: Tween = null
+
+
+func _ready() -> void:
+	fill_rect.color = fill_color
+	# 将背景色应用到 Panel 的样式
+	var style := get_theme_stylebox("panel")
+	if style is StyleBoxFlat:
+		style.bg_color = bg_color
+
+
+## 扩容扫光动画：从 0 → 满 → 回落至指定比例
+func play_sweep_animation(final_ratio: float) -> void:
+	final_ratio = clampf(final_ratio, 0.0, 1.0)
+	if _tween and _tween.is_valid():
+		_tween.kill()
+
+	fill_rect.offset_bottom = 0.0
+	_tween = create_tween().set_parallel(false)
+	# 阶段 1：从上到下扫满全格（扩容感）
+	_tween.tween_property(fill_rect, "offset_bottom", size.y, 0.3)\
+		.set_ease(Tween.EASE_IN_OUT)\
+		.set_trans(Tween.TRANS_CUBIC)
+	# 阶段 2：回落至真实填充率
+	_tween.tween_property(fill_rect, "offset_bottom", size.y * final_ratio, 0.1)\
+		.set_ease(Tween.EASE_OUT)\
+		.set_trans(Tween.TRANS_CUBIC)
+
+
+## 动画填充到指定比例（0 = 空, 1 = 满）
+func animate_fill(ratio: float, duration: float = 0.3) -> void:
+	ratio = clampf(ratio, 0.0, 1.0)
+	var target_height := size.y * ratio
+
+	if _tween and _tween.is_valid():
+		_tween.kill()
+
+	_tween = create_tween()
+	_tween.tween_property(fill_rect, "offset_bottom", target_height, duration)\
+		.set_ease(Tween.EASE_OUT)\
+		.set_trans(Tween.TRANS_CUBIC)
+
+
+## 立即设置填充比例（无动画）
+func set_fill_immediate(ratio: float) -> void:
+	ratio = clampf(ratio, 0.0, 1.0)
+	if fill_rect:
+		fill_rect.offset_bottom = size.y * ratio

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,6 +1,8 @@
 class_name HealthSegment
 extends Panel
 
+const MIN_FILL_HEIGHT: float = 1.0
+
 ## 血量格子填充矩形
 @onready var fill_rect: ColorRect = $FillRect
 
@@ -26,7 +28,8 @@ func _get_fill_height() -> float:
 	var target_height := size.y
 	if target_height <= 0.0:
 		target_height = custom_minimum_size.y
-	return maxf(target_height, 1.0)
+	# 至少保底 1px，避免目标高度为 0 导致补间不可见。
+	return maxf(target_height, MIN_FILL_HEIGHT)
 
 
 ## 扩容扫光动画：从 0 → 满 → 回落至指定比例

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -25,11 +25,12 @@ func _ready() -> void:
 ## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
 ## 此时回退到 custom_minimum_size.y，避免扫光动画目标高度丢失。
 func _get_fill_height() -> float:
-	var target_height := size.y
-	if target_height <= 0.0:
-		target_height = custom_minimum_size.y
+	if size.y > 0.0:
+		return size.y
+	if custom_minimum_size.y > 0.0:
+		return custom_minimum_size.y
 	# 至少保底 1px，避免目标高度为 0 导致补间不可见。
-	return maxf(target_height, MIN_FILL_HEIGHT)
+	return MIN_FILL_HEIGHT
 
 
 ## 扩容扫光动画：从 0 → 满 → 回落至指定比例

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -20,6 +20,8 @@ func _ready() -> void:
 		style.bg_color = bg_color
 
 
+## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
+## 此时回退到 custom_minimum_size.y，避免扫光动画目标高度丢失。
 func _get_fill_height() -> float:
 	var target_height := size.y
 	if target_height <= 0.0:

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -23,7 +23,8 @@ func _ready() -> void:
 
 
 ## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
-## 此时回退到 custom_minimum_size.y，避免扫光动画目标高度丢失。
+## 此时回退到 custom_minimum_size.y（本格在场景里固定为 18px），避免扫光动画目标高度丢失；
+## 若两者都不可用，再用 MIN_FILL_HEIGHT 保底，确保补间仍可见。
 func _get_fill_height() -> float:
 	if size.y > 0.0:
 		return size.y

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 
 
 ## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
-## 此时回退到 custom_minimum_size.y（本格在场景里固定为 18px），避免扫光动画目标高度丢失；
+## 此时回退到 custom_minimum_size.y，避免扫光动画目标高度丢失；
 ## 若两者都不可用，再用 MIN_FILL_HEIGHT_PX（1px）保底，确保补间仍可见。
 func _get_fill_height() -> float:
 	if size.y > 0.0:

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -20,20 +20,28 @@ func _ready() -> void:
 		style.bg_color = bg_color
 
 
+func _get_fill_height() -> float:
+	var target_height := size.y
+	if target_height <= 0.0:
+		target_height = custom_minimum_size.y
+	return maxf(target_height, 1.0)
+
+
 ## 扩容扫光动画：从 0 → 满 → 回落至指定比例
 func play_sweep_animation(final_ratio: float) -> void:
 	final_ratio = clampf(final_ratio, 0.0, 1.0)
 	if _tween and _tween.is_valid():
 		_tween.kill()
 
+	var fill_height := _get_fill_height()
 	fill_rect.offset_bottom = 0.0
 	_tween = create_tween().set_parallel(false)
 	# 阶段 1：从上到下扫满全格（扩容感）
-	_tween.tween_property(fill_rect, "offset_bottom", size.y, 0.3)\
+	_tween.tween_property(fill_rect, "offset_bottom", fill_height, 0.3)\
 		.set_ease(Tween.EASE_IN_OUT)\
 		.set_trans(Tween.TRANS_CUBIC)
 	# 阶段 2：回落至真实填充率
-	_tween.tween_property(fill_rect, "offset_bottom", size.y * final_ratio, 0.1)\
+	_tween.tween_property(fill_rect, "offset_bottom", fill_height * final_ratio, 0.1)\
 		.set_ease(Tween.EASE_OUT)\
 		.set_trans(Tween.TRANS_CUBIC)
 
@@ -41,7 +49,7 @@ func play_sweep_animation(final_ratio: float) -> void:
 ## 动画填充到指定比例（0 = 空, 1 = 满）
 func animate_fill(ratio: float, duration: float = 0.3) -> void:
 	ratio = clampf(ratio, 0.0, 1.0)
-	var target_height := size.y * ratio
+	var target_height := _get_fill_height() * ratio
 
 	if _tween and _tween.is_valid():
 		_tween.kill()
@@ -56,4 +64,4 @@ func animate_fill(ratio: float, duration: float = 0.3) -> void:
 func set_fill_immediate(ratio: float) -> void:
 	ratio = clampf(ratio, 0.0, 1.0)
 	if fill_rect:
-		fill_rect.offset_bottom = size.y * ratio
+		fill_rect.offset_bottom = _get_fill_height() * ratio

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,3 +1,4 @@
+class_name HealthSegment
 extends Panel
 
 ## 血量格子填充矩形

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,7 +1,7 @@
 class_name HealthSegment
 extends Panel
 
-const MIN_FILL_HEIGHT: float = 1.0
+const MIN_FILL_HEIGHT_PX: float = 1.0
 
 ## 血量格子填充矩形
 @onready var fill_rect: ColorRect = $FillRect
@@ -24,14 +24,14 @@ func _ready() -> void:
 
 ## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
 ## 此时回退到 custom_minimum_size.y（本格在场景里固定为 18px），避免扫光动画目标高度丢失；
-## 若两者都不可用，再用 MIN_FILL_HEIGHT 保底，确保补间仍可见。
+## 若两者都不可用，再用 MIN_FILL_HEIGHT_PX（1px）保底，确保补间仍可见。
 func _get_fill_height() -> float:
 	if size.y > 0.0:
 		return size.y
 	if custom_minimum_size.y > 0.0:
 		return custom_minimum_size.y
 	# 至少保底 1px，避免目标高度为 0 导致补间不可见。
-	return MIN_FILL_HEIGHT
+	return MIN_FILL_HEIGHT_PX
 
 
 ## 扩容扫光动画：从 0 → 满 → 回落至指定比例

--- a/health/health_segment.gd.uid
+++ b/health/health_segment.gd.uid
@@ -1,0 +1,1 @@
+uid://pucfxk9drm2wq

--- a/health/health_segment.tscn
+++ b/health/health_segment.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://healthsegment001"]
+
+[ext_resource type="Script" path="res://health/health_segment.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)
+
+[node name="HealthSegment" type="Panel"]
+clip_contents = true
+custom_minimum_size = Vector2(20, 18)
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+script = ExtResource("1_script")
+
+[node name="FillRect" type="ColorRect" parent="."]
+anchors_preset = 10
+anchor_bottom = 0.0
+offset_top = 0.0
+offset_bottom = 0.0
+grow_vertical = 1
+color = Color(0.905882, 0.298039, 0.235294, 1)
+mouse_filter = 2

--- a/health/health_segment.tscn
+++ b/health/health_segment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://healthsegment001"]
+[gd_scene load_steps=3 format=3 uid="uid://jfi132vfa2wh6"]
 
 [ext_resource type="Script" path="res://health/health_segment.gd" id="1_script"]
 

--- a/health/health_segment.tscn.uid
+++ b/health/health_segment.tscn.uid
@@ -1,0 +1,1 @@
+uid://jfi132vfa2wh6

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -56,7 +56,7 @@ func _on_health_changed(_current: int, _max: int) -> void:
 	_sync_cell_count()
 	var after_count := container.get_child_count()
 	# 假设：单次 health_changed 不会出现“先减后增”的格子变化（当前 max_health_up 仅增加）。
-	# 若未来引入该场景，需要改成记录具体节点集合而不是区间差值。
+	# 若该假设被打破，区间差值可能指向错误格子，导致扫光播错目标；届时需改为记录具体节点集合。
 	if after_count > before_count:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -1,6 +1,7 @@
 extends CanvasLayer
 
 const Health = preload("res://health/health.gd")
+const HealthSegment = preload("res://health/health_segment.gd")
 const CELL_HP: int = 10
 const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
 

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -55,6 +55,8 @@ func _on_health_changed(_current: int, _max: int) -> void:
 	var before_count := container.get_child_count()
 	_sync_cell_count()
 	var after_count := container.get_child_count()
+	# 当前流程里 max_health_up 只会让格子单调增加；若未来引入同帧减后增，
+	# 需要改成记录具体节点集合而不是区间差值。
 	if after_count > before_count:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -9,7 +9,8 @@ const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
 
 var player: CharacterBody2D
 var health: Health
-var _last_known_cell_count: int = 0
+var _pending_added_start_index: int = -1
+var _pending_added_count: int = 0
 
 
 func _ready() -> void:
@@ -27,7 +28,6 @@ func _init_segments() -> void:
 	var cell_count := _calc_cell_count()
 	for i in range(cell_count):
 		_add_segment()
-	_last_known_cell_count = cell_count
 
 
 ## 按每格 CELL_HP 血量计算所需格子数（取上整）
@@ -52,7 +52,15 @@ func _remove_segment() -> void:
 # ─── 信号回调 ──────────────────────────────────────────────────────────
 
 func _on_health_changed(_current: int, _max: int) -> void:
+	var before_count := container.get_child_count()
 	_sync_cell_count()
+	var after_count := container.get_child_count()
+	if after_count > before_count:
+		_pending_added_start_index = before_count
+		_pending_added_count = after_count - before_count
+	else:
+		_pending_added_start_index = -1
+		_pending_added_count = 0
 	_update_all_fills()
 
 
@@ -60,22 +68,21 @@ func _on_pick_feedback(ability_id: String, _level: int) -> void:
 	if ability_id != "max_health_up":
 		return
 
-	# 此时 health.max_health 已被管线更新（abilities_updated 先于本信号同步发射）
-	var new_count := _calc_cell_count()
-	if new_count <= _last_known_cell_count:
+	if _pending_added_count <= 0 or _pending_added_start_index < 0:
 		return
 
-	# 为每个新增格子播放扩容扫光动画
-	var cells_to_add := new_count - _last_known_cell_count
 	var current_val := health.current_health
-	for i in range(cells_to_add):
-		var seg := _add_segment()
-		var cell_index := _last_known_cell_count + i
+	for i in range(_pending_added_count):
+		var cell_index := _pending_added_start_index + i
+		var seg := container.get_child(cell_index) as HealthSegment
+		if seg == null:
+			continue
 		var cell_start := cell_index * CELL_HP
 		var actual_fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
 		seg.play_sweep_animation(actual_fill)
 
-	_last_known_cell_count = new_count
+	_pending_added_start_index = -1
+	_pending_added_count = 0
 
 
 # ─── 内部辅助 ──────────────────────────────────────────────────────────
@@ -90,8 +97,6 @@ func _sync_cell_count() -> void:
 	while current > target:
 		_remove_segment()
 		current -= 1
-
-	_last_known_cell_count = target
 
 
 func _update_all_fills() -> void:

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -75,8 +75,6 @@ func _on_pick_feedback(ability_id: String, _level: int) -> void:
 	for i in range(_pending_added_count):
 		var cell_index := _pending_added_start_index + i
 		var seg := container.get_child(cell_index) as HealthSegment
-		if seg == null:
-			continue
 		var cell_start := cell_index * CELL_HP
 		var actual_fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
 		seg.play_sweep_animation(actual_fill)

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -59,6 +59,7 @@ func _on_health_changed(_current: int, _max: int) -> void:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count
 	else:
+		# 主动清零，避免上一次新增区间误用于后续反馈。
 		_pending_added_start_index = -1
 		_pending_added_count = 0
 	_update_all_fills()

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -55,8 +55,8 @@ func _on_health_changed(_current: int, _max: int) -> void:
 	var before_count := container.get_child_count()
 	_sync_cell_count()
 	var after_count := container.get_child_count()
-	# 当前流程里 max_health_up 只会让格子单调增加；若未来引入同帧减后增，
-	# 需要改成记录具体节点集合而不是区间差值。
+	# 假设：单次 health_changed 不会出现“先减后增”的格子变化（当前 max_health_up 仅增加）。
+	# 若未来引入该场景，需要改成记录具体节点集合而不是区间差值。
 	if after_count > before_count:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -11,6 +11,7 @@ var player: CharacterBody2D
 var health: Health
 var _pending_added_start_index: int = -1
 var _pending_added_count: int = 0
+var _initialized := false
 
 
 func _ready() -> void:
@@ -21,7 +22,13 @@ func _ready() -> void:
 	EventBus.on_pick_feedback.connect(_on_pick_feedback)
 
 	_init_segments()
-	_update_all_fills()
+
+
+func _process(_delta: float) -> void:
+	if not _initialized:
+		_initialized = true
+		_update_all_fills()
+		set_process(false)
 
 
 func _init_segments() -> void:
@@ -76,7 +83,7 @@ func _on_pick_feedback(ability_id: String, _level: int) -> void:
 		var seg := container.get_child(cell_index) as HealthSegment
 		var cell_start := cell_index * CELL_HP
 		var actual_fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
-		seg.play_sweep_animation(actual_fill)
+		seg.play_sweep_animation.call_deferred(actual_fill)
 
 	_pending_added_start_index = -1
 	_pending_added_count = 0

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -1,18 +1,102 @@
 extends CanvasLayer
 
 const Health = preload("res://health/health.gd")
+const CELL_HP: int = 10
+const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
 
-@onready var progress_bar: ProgressBar = $ProgressBar
+@onready var container: HBoxContainer = $SegmentsContainer
+
 var player: CharacterBody2D
 var health: Health
+var _last_known_cell_count: int = 0
+
 
 func _ready() -> void:
 	player = get_node("/root/main/player")
 	health = player.get_node("health")
-	health.health_changed.connect(_on_health_changed)
-	progress_bar.max_value = health.max_health
-	progress_bar.value = health.current_health
 
-func _on_health_changed(current: int, max: int) -> void:
-	progress_bar.max_value = max
-	progress_bar.value = current
+	health.health_changed.connect(_on_health_changed)
+	EventBus.on_pick_feedback.connect(_on_pick_feedback)
+
+	_init_segments()
+	_update_all_fills()
+
+
+func _init_segments() -> void:
+	var cell_count := _calc_cell_count()
+	for i in range(cell_count):
+		_add_segment()
+	_last_known_cell_count = cell_count
+
+
+## 按每格 CELL_HP 血量计算所需格子数（取上整）
+func _calc_cell_count() -> int:
+	return maxi(1, ceili(float(health.max_health) / CELL_HP))
+
+
+func _add_segment() -> HealthSegment:
+	var seg: HealthSegment = SEGMENT_SCENE.instantiate()
+	seg.size_flags_horizontal = Control.SIZE_EXPAND | Control.SIZE_FILL
+	seg.size_flags_vertical   = Control.SIZE_EXPAND | Control.SIZE_FILL
+	container.add_child(seg)
+	return seg
+
+
+func _remove_segment() -> void:
+	var count := container.get_child_count()
+	if count > 0:
+		container.get_child(count - 1).queue_free()
+
+
+# ─── 信号回调 ──────────────────────────────────────────────────────────
+
+func _on_health_changed(_current: int, _max: int) -> void:
+	_sync_cell_count()
+	_update_all_fills()
+
+
+func _on_pick_feedback(ability_id: String, _level: int) -> void:
+	if ability_id != "max_health_up":
+		return
+
+	# 此时 health.max_health 已被管线更新（abilities_updated 先于本信号同步发射）
+	var new_count := _calc_cell_count()
+	if new_count <= _last_known_cell_count:
+		return
+
+	# 为每个新增格子播放扩容扫光动画
+	var cells_to_add := new_count - _last_known_cell_count
+	var current_val := health.current_health
+	for i in range(cells_to_add):
+		var seg := _add_segment()
+		var cell_index := _last_known_cell_count + i
+		var cell_start := cell_index * CELL_HP
+		var actual_fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
+		seg.play_sweep_animation(actual_fill)
+
+	_last_known_cell_count = new_count
+
+
+# ─── 内部辅助 ──────────────────────────────────────────────────────────
+
+func _sync_cell_count() -> void:
+	var target := _calc_cell_count()
+	var current := container.get_child_count()
+
+	while current < target:
+		_add_segment()
+		current += 1
+	while current > target:
+		_remove_segment()
+		current -= 1
+
+	_last_known_cell_count = target
+
+
+func _update_all_fills() -> void:
+	var current_val := health.current_health
+	for i in range(container.get_child_count()):
+		var seg: HealthSegment = container.get_child(i)
+		var cell_start := i * CELL_HP
+		var fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
+		seg.set_fill_immediate(fill)

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -58,10 +58,6 @@ func _on_health_changed(_current: int, _max: int) -> void:
 	if after_count > before_count:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count
-	else:
-		# 主动清零，避免上一次新增区间误用于后续反馈。
-		_pending_added_start_index = -1
-		_pending_added_count = 0
 	_update_all_fills()
 
 

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -68,7 +68,7 @@ func _on_pick_feedback(ability_id: String, _level: int) -> void:
 	if ability_id != "max_health_up":
 		return
 
-	if _pending_added_count <= 0 or _pending_added_start_index < 0:
+	if _pending_added_count <= 0:
 		return
 
 	var current_val := health.current_health

--- a/health/health_ui.tscn
+++ b/health/health_ui.tscn
@@ -1,24 +1,14 @@
-[gd_scene format=3 uid="uid://healthui001"]
+[gd_scene load_steps=2 format=3 uid="uid://healthui001"]
 
 [ext_resource type="Script" path="res://health/health_ui.gd" id="1_script"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
-bg_color = Color(0.2, 0.2, 0.2, 0.8)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fill"]
-bg_color = Color(0.905882, 0.298039, 0.235294, 1)
+[ext_resource type="PackedScene" path="res://health/health_segment.tscn" id="2_segment_scene"]
 
 [node name="HealthUI" type="CanvasLayer"]
 script = ExtResource("1_script")
 
-[node name="ProgressBar" type="ProgressBar" parent="."]
+[node name="SegmentsContainer" type="HBoxContainer" parent="."]
 offset_left = 120.0
 offset_top = 20.0
 offset_right = 520.0
 offset_bottom = 40.0
-theme_override_styles/background = SubResource("StyleBoxFlat_bg")
-theme_override_styles/fill = SubResource("StyleBoxFlat_fill")
-max_value = 100.0
-step = 1.0
-value = 100.0
-show_percentage = false
+theme_override_constants/separation = 2


### PR DESCRIPTION
## 实现内容

实现 Issue #42 — max_health_up 选择反馈：血量条填充动画

### 变更文件

| 文件 | 操作 | 说明 |
|------|------|------|
| ability/event_bus.gd | 修改 | 新增 on_pick_feedback 信号 |
| ability/ability_manager.gd | 修改 | select_ability() 末尾发射新信号 |
| health/health_segment.gd | 新建 | 单格组件：扫光动画 + 填充逻辑 |
| health/health_segment.tscn | 新建 | Panel + FillRect（顶部锚定，clip） |
| health/health_ui.gd | 重写 | ProgressBar → HBoxContainer 分段格子管理 |
| health/health_ui.tscn | 修改 | ProgressBar → SegmentsContainer |

### 架构

HealthUI (CanvasLayer) → HBoxContainer → HealthSegment[] (每格 = 10 HP)

### 动画效果
- 选 max_health_up → 新增格子 → 从上到下扫光填充 (0.3s) → 回落至真实填充率 (0.1s)
- 不阻塞战斗（Tween 异步运行，无 await）

Closes #42