### PR TITLE
feat(health-ui): max_health_up 选择反馈 — 分段血量条 + 扩容扫光动画

### DIFF
--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -113,6 +113,7 @@ func select_ability(ability_id: String) -> void:
 	_rebuild_pipeline()
 	ability_acquired.emit(ability_id, final_inst.get_stack_count() if final_inst else 1)
 	abilities_updated.emit()
+	EventBus.on_pick_feedback.emit(ability_id, final_inst.get_stack_count() if final_inst else 1)
 	_finish_level_up_selection()
 
 

--- a/ability/event_bus.gd
+++ b/ability/event_bus.gd
@@ -19,6 +19,8 @@ signal on_crit(context: Dictionary)
 # ---------- 能力系统事件 ----------
 ## 获得新能力
 signal on_ability_acquired(ability_id: String, level: int)
+## 选择能力后的专属视觉反馈（非阻塞动画）
+signal on_pick_feedback(ability_id: String, level: int)
 ## 联动激活
 signal on_synergy_activated(synergy_id: String)
 ## 反击螺旋触发

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -34,7 +34,7 @@ func _apply_fill_ratio(ratio: float) -> void:
 ## 扩容扫光动画：从 0 → 满 → 回落至指定比例（tween anchor_bottom）
 func play_sweep_animation(final_ratio: float) -> void:
 	final_ratio = clampf(final_ratio, 0.0, 1.0)
-	if _tween and _tween.is_valid():
+	if _tween != null:
 		_tween.kill()
 	_apply_fill_ratio(0.0)
 	_tween = create_tween().set_parallel(false)
@@ -51,7 +51,7 @@ func play_sweep_animation(final_ratio: float) -> void:
 ## 立即设置填充比例（无动画）
 func set_fill_immediate(ratio: float) -> void:
 	ratio = clampf(ratio, 0.0, 1.0)
-	if _tween and _tween.is_valid():
+	if _tween != null:
 		_tween.kill()
 	if fill_rect:
 		_apply_fill_ratio(ratio)

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,8 +1,6 @@
 class_name HealthSegment
 extends Panel
 
-const MIN_FILL_HEIGHT_PX: float = 1.0
-
 ## 血量格子填充矩形
 @onready var fill_rect: ColorRect = $FillRect
 
@@ -21,30 +19,31 @@ func _ready() -> void:
 		style.bg_color = bg_color
 
 
-## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
-## 此时回退到 custom_minimum_size.y，若两者都不可用，再用 MIN_FILL_HEIGHT_PX 保底。
-func _get_fill_height() -> float:
-	if size.y > 0.0:
-		return size.y
-	if custom_minimum_size.y > 0.0:
-		return custom_minimum_size.y
-	return MIN_FILL_HEIGHT_PX
+## 将填充比例应用到 Rect（0~1：anchor_bottom 相对父 Panel 高度）
+func _apply_fill_ratio(ratio: float) -> void:
+	fill_rect.anchor_left = 0.0
+	fill_rect.anchor_top = 0.0
+	fill_rect.anchor_right = 1.0
+	fill_rect.anchor_bottom = ratio
+	fill_rect.offset_left = 0.0
+	fill_rect.offset_top = 0.0
+	fill_rect.offset_right = 0.0
+	fill_rect.offset_bottom = 0.0
 
 
-## 扩容扫光动画：从 0 → 满 → 回落至指定比例
+## 扩容扫光动画：从 0 → 满 → 回落至指定比例（tween anchor_bottom）
 func play_sweep_animation(final_ratio: float) -> void:
 	final_ratio = clampf(final_ratio, 0.0, 1.0)
 	if _tween and _tween.is_valid():
 		_tween.kill()
-	var fill_height := _get_fill_height()
-	fill_rect.offset_bottom = 0.0
+	_apply_fill_ratio(0.0)
 	_tween = create_tween().set_parallel(false)
 	# 阶段 1：从上到下扫满全格（扩容感）
-	_tween.tween_property(fill_rect, "offset_bottom", fill_height, 0.3) \
+	_tween.tween_property(fill_rect, "anchor_bottom", 1.0, 0.3) \
 		.set_ease(Tween.EASE_IN_OUT) \
 		.set_trans(Tween.TRANS_CUBIC)
 	# 阶段 2：回落至真实填充率
-	_tween.tween_property(fill_rect, "offset_bottom", fill_height * final_ratio, 0.1) \
+	_tween.tween_property(fill_rect, "anchor_bottom", final_ratio, 0.1) \
 		.set_ease(Tween.EASE_OUT) \
 		.set_trans(Tween.TRANS_CUBIC)
 
@@ -52,5 +51,7 @@ func play_sweep_animation(final_ratio: float) -> void:
 ## 立即设置填充比例（无动画）
 func set_fill_immediate(ratio: float) -> void:
 	ratio = clampf(ratio, 0.0, 1.0)
+	if _tween and _tween.is_valid():
+		_tween.kill()
 	if fill_rect:
-		fill_rect.offset_bottom = _get_fill_height() * ratio
+		_apply_fill_ratio(ratio)

--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -1,0 +1,56 @@
+class_name HealthSegment
+extends Panel
+
+const MIN_FILL_HEIGHT_PX: float = 1.0
+
+## 血量格子填充矩形
+@onready var fill_rect: ColorRect = $FillRect
+
+## 填充色（红）
+@export var fill_color: Color = Color(0.905882, 0.298039, 0.235294, 1)
+## 背景色（暗灰）
+@export var bg_color: Color = Color(0.2, 0.2, 0.2, 0.8)
+
+var _tween: Tween = null
+
+
+func _ready() -> void:
+	fill_rect.color = fill_color
+	var style := get_theme_stylebox("panel")
+	if style is StyleBoxFlat:
+		style.bg_color = bg_color
+
+
+## HBox 新增子节点后首帧可能尚未完成布局，size.y 会暂时为 0；
+## 此时回退到 custom_minimum_size.y，若两者都不可用，再用 MIN_FILL_HEIGHT_PX 保底。
+func _get_fill_height() -> float:
+	if size.y > 0.0:
+		return size.y
+	if custom_minimum_size.y > 0.0:
+		return custom_minimum_size.y
+	return MIN_FILL_HEIGHT_PX
+
+
+## 扩容扫光动画：从 0 → 满 → 回落至指定比例
+func play_sweep_animation(final_ratio: float) -> void:
+	final_ratio = clampf(final_ratio, 0.0, 1.0)
+	if _tween and _tween.is_valid():
+		_tween.kill()
+	var fill_height := _get_fill_height()
+	fill_rect.offset_bottom = 0.0
+	_tween = create_tween().set_parallel(false)
+	# 阶段 1：从上到下扫满全格（扩容感）
+	_tween.tween_property(fill_rect, "offset_bottom", fill_height, 0.3) \
+		.set_ease(Tween.EASE_IN_OUT) \
+		.set_trans(Tween.TRANS_CUBIC)
+	# 阶段 2：回落至真实填充率
+	_tween.tween_property(fill_rect, "offset_bottom", fill_height * final_ratio, 0.1) \
+		.set_ease(Tween.EASE_OUT) \
+		.set_trans(Tween.TRANS_CUBIC)
+
+
+## 立即设置填充比例（无动画）
+func set_fill_immediate(ratio: float) -> void:
+	ratio = clampf(ratio, 0.0, 1.0)
+	if fill_rect:
+		fill_rect.offset_bottom = _get_fill_height() * ratio

--- a/health/health_segment.gd.uid
+++ b/health/health_segment.gd.uid
@@ -1,0 +1,1 @@
+uid://pucfxk9drm2wq

--- a/health/health_segment.tscn
+++ b/health/health_segment.tscn
@@ -8,14 +8,21 @@ bg_color = Color(0.2, 0.2, 0.2, 0.8)
 [node name="HealthSegment" type="Panel"]
 clip_contents = true
 custom_minimum_size = Vector2(20, 18)
+layout_mode = 2
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
 script = ExtResource("1_script")
 
 [node name="FillRect" type="ColorRect" parent="."]
+layout_mode = 1
 anchors_preset = 10
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
 anchor_bottom = 0.0
+offset_left = 0.0
 offset_top = 0.0
+offset_right = 0.0
 offset_bottom = 0.0
 grow_vertical = 1
 color = Color(0.905882, 0.298039, 0.235294, 1)

--- a/health/health_segment.tscn
+++ b/health/health_segment.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=3 uid="uid://jfi132vfa2wh6"]
+
+[ext_resource type="Script" path="res://health/health_segment.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)
+
+[node name="HealthSegment" type="Panel"]
+clip_contents = true
+custom_minimum_size = Vector2(20, 18)
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+script = ExtResource("1_script")
+
+[node name="FillRect" type="ColorRect" parent="."]
+anchors_preset = 10
+anchor_bottom = 0.0
+offset_top = 0.0
+offset_bottom = 0.0
+grow_vertical = 1
+color = Color(0.905882, 0.298039, 0.235294, 1)
+mouse_filter = 2

--- a/health/health_segment.tscn.uid
+++ b/health/health_segment.tscn.uid
@@ -1,0 +1,1 @@
+uid://jfi132vfa2wh6

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -68,6 +68,9 @@ func _on_health_changed(_current: int, _max: int) -> void:
 		_pending_added_start_index = before_count
 		_pending_added_count = after_count - before_count
 	_update_all_fills()
+	# 新增子格的 @onready 可能在同一帧稍晚完成，再刷一次避免 fill_rect 未就绪时跳过
+	if after_count > before_count:
+		call_deferred("_update_all_fills")
 
 
 func _on_pick_feedback(ability_id: String, _level: int) -> void:

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -1,18 +1,112 @@
 extends CanvasLayer
 
 const Health = preload("res://health/health.gd")
+const HealthSegment = preload("res://health/health_segment.gd")
+const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
+const CELL_HP: int = 10
 
-@onready var progress_bar: ProgressBar = $ProgressBar
+@onready var container: HBoxContainer = $SegmentsContainer
+
 var player: CharacterBody2D
 var health: Health
+
+# 记录上一次 _on_health_changed 触发后新增的格子范围，供 _on_pick_feedback 播动画
+var _pending_added_start_index: int = -1
+var _pending_added_count: int = 0
+# 布局完成前延迟初始化填充
+var _initialized := false
+
 
 func _ready() -> void:
 	player = get_node("/root/main/player")
 	health = player.get_node("health")
 	health.health_changed.connect(_on_health_changed)
-	progress_bar.max_value = health.max_health
-	progress_bar.value = health.current_health
+	EventBus.on_pick_feedback.connect(_on_pick_feedback)
+	_init_segments()
 
-func _on_health_changed(current: int, max: int) -> void:
-	progress_bar.max_value = max
-	progress_bar.value = current
+
+func _process(_delta: float) -> void:
+	# 等待 HBox 完成布局后再做首次填充，避免 size.y 为 0
+	if not _initialized:
+		_initialized = true
+		_update_all_fills()
+		set_process(false)
+
+
+func _init_segments() -> void:
+	var cell_count := _calc_cell_count()
+	for i in range(cell_count):
+		_add_segment()
+
+
+func _calc_cell_count() -> int:
+	return maxi(1, ceili(float(health.max_health) / CELL_HP))
+
+
+func _add_segment() -> HealthSegment:
+	var seg: HealthSegment = SEGMENT_SCENE.instantiate()
+	seg.size_flags_horizontal = Control.SIZE_EXPAND | Control.SIZE_FILL
+	seg.size_flags_vertical   = Control.SIZE_EXPAND | Control.SIZE_FILL
+	container.add_child(seg)
+	return seg
+
+
+func _remove_segment() -> void:
+	var count := container.get_child_count()
+	if count > 0:
+		container.get_child(count - 1).queue_free()
+
+
+# ─── 信号回调 ─────────────────────────────────────────────────────────────────
+
+func _on_health_changed(_current: int, _max: int) -> void:
+	var before_count := container.get_child_count()
+	_sync_cell_count()
+	var after_count := container.get_child_count()
+	# 记录新增范围供 _on_pick_feedback 使用（假设单次仅增格）
+	if after_count > before_count:
+		_pending_added_start_index = before_count
+		_pending_added_count = after_count - before_count
+	_update_all_fills()
+
+
+func _on_pick_feedback(ability_id: String, _level: int) -> void:
+	if ability_id != "max_health_up":
+		return
+	if _pending_added_count <= 0:
+		return
+
+	var current_val := health.current_health
+	for i in range(_pending_added_count):
+		var cell_index := _pending_added_start_index + i
+		var seg := container.get_child(cell_index) as HealthSegment
+		var cell_start := cell_index * CELL_HP
+		var actual_fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
+		# 延迟一帧确保 HBox 布局完成，size.y 有效
+		seg.play_sweep_animation.call_deferred(actual_fill)
+
+	_pending_added_start_index = -1
+	_pending_added_count = 0
+
+
+# ─── 内部辅助 ─────────────────────────────────────────────────────────────────
+
+func _sync_cell_count() -> void:
+	var target := _calc_cell_count()
+	var current := container.get_child_count()
+	while current < target:
+		_add_segment()
+		current += 1
+	while current > target:
+		_remove_segment()
+		current -= 1
+
+
+func _update_all_fills() -> void:
+	var current_val := health.current_health
+	for i in range(container.get_child_count()):
+		var seg: HealthSegment = container.get_child(i)
+		var cell_start := i * CELL_HP
+		var fill := clampf(float(current_val - cell_start) / CELL_HP, 0.0, 1.0)
+		seg.set_fill_immediate(fill)
+

--- a/health/health_ui.tscn
+++ b/health/health_ui.tscn
@@ -1,24 +1,15 @@
-[gd_scene format=3 uid="uid://healthui001"]
+[gd_scene load_steps=2 format=3 uid="uid://healthui001"]
 
 [ext_resource type="Script" path="res://health/health_ui.gd" id="1_script"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
-bg_color = Color(0.2, 0.2, 0.2, 0.8)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fill"]
-bg_color = Color(0.905882, 0.298039, 0.235294, 1)
+[ext_resource type="PackedScene" path="res://health/health_segment.tscn" id="2_segment_scene"]
 
 [node name="HealthUI" type="CanvasLayer"]
 script = ExtResource("1_script")
 
-[node name="ProgressBar" type="ProgressBar" parent="."]
+[node name="SegmentsContainer" type="HBoxContainer" parent="."]
 offset_left = 120.0
 offset_top = 20.0
 offset_right = 520.0
 offset_bottom = 40.0
-theme_override_styles/background = SubResource("StyleBoxFlat_bg")
-theme_override_styles/fill = SubResource("StyleBoxFlat_fill")
-max_value = 100.0
-step = 1.0
-value = 100.0
-show_percentage = false
+theme_override_constants/separation = 2
+

--- a/health/health_ui.tscn
+++ b/health/health_ui.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://healthui001"]
+[gd_scene load_steps=1 format=3 uid="uid://healthui001"]
 
 [ext_resource type="Script" path="res://health/health_ui.gd" id="1_script"]
-[ext_resource type="PackedScene" path="res://health/health_segment.tscn" id="2_segment_scene"]
 
 [node name="HealthUI" type="CanvasLayer"]
 script = ExtResource("1_script")
@@ -12,4 +11,3 @@ offset_top = 20.0
 offset_right = 520.0
 offset_bottom = 40.0
 theme_override_constants/separation = 2
-


### PR DESCRIPTION
## 实现内容

实现 Issue #42 — max_health_up 选择反馈：血量条填充动画

### 变更文件

| 文件 | 操作 | 说明 |
|------|------|------|
| ability/event_bus.gd | 修改 | 新增 on_pick_feedback 信号 |
| ability/ability_manager.gd | 修改 | select_ability() 末尾发射新信号 |
| health/health_segment.gd | 新建 | 单格组件：扫光动画 + 即时填充 API |
| health/health_segment.tscn | 新建 | Panel + FillRect（顶部锚定，clip） |
| health/health_ui.gd | 重写 | ProgressBar → HBoxContainer 分段格子管理 |
| health/health_ui.tscn | 修改 | ProgressBar → SegmentsContainer |

### 架构

HealthUI (CanvasLayer) → HBoxContainer → HealthSegment[] (每格 = 10 HP)

### 动画效果
- 选 max_health_up → 新增格子 → 从上到下扫光填充 (0.3s) → 回落至真实填充率 (0.1s)
- 不阻塞战斗（Tween 异步运行，call_deferred 确保布局完成后执行）
- 首次填充延迟到布局完成后（_process 单帧延迟），避免 size.y 为 0

Closes #42