### PR TITLE
fix(ci): PR close 时更新所有 PR 预览评论，而非仅第一条

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -299,14 +299,16 @@ jobs:
                 per_page: 100,
               }
             );
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
+            const existingList = comments.filter(c => c.body && c.body.includes(marker));
+            if (existingList.length > 0) {
+              for (const existing of existingList) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              }
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## 问题

PR 多次提交后产生多条「PR 预览」评论，但 PR merge/close 后只有第一条被更新为「已下线」，其余评论保持不变。

## 根因

 job 的 GitHub Script 中使用的是 `comments.find()`，只匹配了第一条带 `<!-- shield-core-pr-preview -->` 标记的评论。

## 修复

改为 `comments.filter()` 匹配所有带标记的评论，并用 `for...of` 循环逐条调用 `updateComment`。

**改动文件：** `.github/workflows/pr-preview.yml`