### PR TITLE
feat(health-ui): health_regen 选择反馈 — 绿闪与 +1 浮字

### DIFF
--- a/health/health_segment.gd
+++ b/health/health_segment.gd
@@ -6,6 +6,8 @@ extends Panel
 
 ## 填充色（红）
 @export var fill_color: Color = Color(0.905882, 0.298039, 0.235294, 1)
+## 恢复反馈闪烁色（鲜绿）
+const REGEN_FLASH_COLOR := Color(0.22, 0.95, 0.38, 1)
 ## 背景色（暗灰）
 @export var bg_color: Color = Color(0.2, 0.2, 0.2, 0.8)
 
@@ -46,6 +48,22 @@ func play_sweep_animation(final_ratio: float) -> void:
 	_tween.tween_property(fill_rect, "anchor_bottom", final_ratio, 0.1) \
 		.set_ease(Tween.EASE_OUT) \
 		.set_trans(Tween.TRANS_CUBIC)
+
+
+## 选择 health_regen 时：填充条闪绿约 0.3 秒
+func play_regen_flash(duration: float = 0.3) -> void:
+	if not fill_rect:
+		return
+	if _tween != null:
+		_tween.kill()
+	var half := duration * 0.5
+	_tween = create_tween()
+	_tween.tween_property(fill_rect, "color", REGEN_FLASH_COLOR, half) \
+		.set_ease(Tween.EASE_OUT) \
+		.set_trans(Tween.TRANS_SINE)
+	_tween.tween_property(fill_rect, "color", fill_color, half) \
+		.set_ease(Tween.EASE_IN) \
+		.set_trans(Tween.TRANS_SINE)
 
 
 ## 立即设置填充比例（无动画）

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -6,13 +6,9 @@ const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
 const CELL_HP: int = 10
 
 @onready var container: HBoxContainer = $SegmentsContainer
-@onready var regen_popup_label: Label = $regen_popup_label
 
 var player: CharacterBody2D
 var health: Health
-
-var _regen_popup_base_position: Vector2 = Vector2.ZERO
-var _regen_popup_tween: Tween = null
 
 # 记录上一次 _on_health_changed 触发后新增的格子范围，供 _on_pick_feedback 播动画
 var _pending_added_start_index: int = -1
@@ -26,8 +22,6 @@ func _ready() -> void:
 	health = player.get_node("health")
 	health.health_changed.connect(_on_health_changed)
 	EventBus.on_pick_feedback.connect(_on_pick_feedback)
-	_regen_popup_base_position = regen_popup_label.position
-	regen_popup_label.hide()
 	_init_segments()
 
 
@@ -109,39 +103,6 @@ func _play_health_regen_feedback() -> void:
 		var seg := child as HealthSegment
 		if seg:
 			seg.play_regen_flash()
-	_show_regen_popup()
-
-
-func _show_regen_popup() -> void:
-	regen_popup_label.text = "+1"
-	regen_popup_label.position = _regen_popup_base_position
-	regen_popup_label.modulate = Color(1, 1, 1, 1)
-	regen_popup_label.show()
-
-	if _regen_popup_tween != null:
-		_regen_popup_tween.kill()
-
-	_regen_popup_tween = create_tween()
-	_regen_popup_tween.set_parallel(true)
-	_regen_popup_tween.tween_property(
-		regen_popup_label,
-		"position",
-		_regen_popup_base_position + Vector2(0, -14),
-		0.5
-	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
-	_regen_popup_tween.tween_property(
-		regen_popup_label,
-		"modulate",
-		Color(1, 1, 1, 0),
-		0.5
-	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
-	_regen_popup_tween.finished.connect(_on_regen_popup_finished)
-
-
-func _on_regen_popup_finished() -> void:
-	regen_popup_label.hide()
-	regen_popup_label.position = _regen_popup_base_position
-	regen_popup_label.modulate = Color(1, 1, 1, 1)
 
 
 # ─── 内部辅助 ─────────────────────────────────────────────────────────────────

--- a/health/health_ui.gd
+++ b/health/health_ui.gd
@@ -6,9 +6,13 @@ const SEGMENT_SCENE = preload("res://health/health_segment.tscn")
 const CELL_HP: int = 10
 
 @onready var container: HBoxContainer = $SegmentsContainer
+@onready var regen_popup_label: Label = $regen_popup_label
 
 var player: CharacterBody2D
 var health: Health
+
+var _regen_popup_base_position: Vector2 = Vector2.ZERO
+var _regen_popup_tween: Tween = null
 
 # 记录上一次 _on_health_changed 触发后新增的格子范围，供 _on_pick_feedback 播动画
 var _pending_added_start_index: int = -1
@@ -22,6 +26,8 @@ func _ready() -> void:
 	health = player.get_node("health")
 	health.health_changed.connect(_on_health_changed)
 	EventBus.on_pick_feedback.connect(_on_pick_feedback)
+	_regen_popup_base_position = regen_popup_label.position
+	regen_popup_label.hide()
 	_init_segments()
 
 
@@ -74,8 +80,14 @@ func _on_health_changed(_current: int, _max: int) -> void:
 
 
 func _on_pick_feedback(ability_id: String, _level: int) -> void:
-	if ability_id != "max_health_up":
-		return
+	match ability_id:
+		"max_health_up":
+			_play_max_health_up_feedback()
+		"health_regen":
+			_play_health_regen_feedback()
+
+
+func _play_max_health_up_feedback() -> void:
 	if _pending_added_count <= 0:
 		return
 
@@ -90,6 +102,46 @@ func _on_pick_feedback(ability_id: String, _level: int) -> void:
 
 	_pending_added_start_index = -1
 	_pending_added_count = 0
+
+
+func _play_health_regen_feedback() -> void:
+	for child in container.get_children():
+		var seg := child as HealthSegment
+		if seg:
+			seg.play_regen_flash()
+	_show_regen_popup()
+
+
+func _show_regen_popup() -> void:
+	regen_popup_label.text = "+1"
+	regen_popup_label.position = _regen_popup_base_position
+	regen_popup_label.modulate = Color(1, 1, 1, 1)
+	regen_popup_label.show()
+
+	if _regen_popup_tween != null:
+		_regen_popup_tween.kill()
+
+	_regen_popup_tween = create_tween()
+	_regen_popup_tween.set_parallel(true)
+	_regen_popup_tween.tween_property(
+		regen_popup_label,
+		"position",
+		_regen_popup_base_position + Vector2(0, -14),
+		0.5
+	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	_regen_popup_tween.tween_property(
+		regen_popup_label,
+		"modulate",
+		Color(1, 1, 1, 0),
+		0.5
+	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	_regen_popup_tween.finished.connect(_on_regen_popup_finished)
+
+
+func _on_regen_popup_finished() -> void:
+	regen_popup_label.hide()
+	regen_popup_label.position = _regen_popup_base_position
+	regen_popup_label.modulate = Color(1, 1, 1, 1)
 
 
 # ─── 内部辅助 ─────────────────────────────────────────────────────────────────

--- a/health/health_ui.tscn
+++ b/health/health_ui.tscn
@@ -11,3 +11,17 @@ offset_top = 20.0
 offset_right = 520.0
 offset_bottom = 40.0
 theme_override_constants/separation = 2
+
+[node name="regen_popup_label" type="Label" parent="."]
+visible = false
+offset_left = 120.0
+offset_top = 2.0
+offset_right = 520.0
+offset_bottom = 20.0
+mouse_filter = 2
+text = "+1"
+horizontal_alignment = 1
+theme_override_colors/font_color = Color(0.35, 0.98, 0.45, 1)
+theme_override_colors/font_outline_color = Color(0.05, 0.15, 0.08, 0.9)
+theme_override_constants/outline_size = 2
+theme_override_font_sizes/font_size = 16

--- a/health/health_ui.tscn
+++ b/health/health_ui.tscn
@@ -11,17 +11,3 @@ offset_top = 20.0
 offset_right = 520.0
 offset_bottom = 40.0
 theme_override_constants/separation = 2
-
-[node name="regen_popup_label" type="Label" parent="."]
-visible = false
-offset_left = 120.0
-offset_top = 2.0
-offset_right = 520.0
-offset_bottom = 20.0
-mouse_filter = 2
-text = "+1"
-horizontal_alignment = 1
-theme_override_colors/font_color = Color(0.35, 0.98, 0.45, 1)
-theme_override_colors/font_outline_color = Color(0.05, 0.15, 0.08, 0.9)
-theme_override_constants/outline_size = 2
-theme_override_font_sizes/font_size = 16


### PR DESCRIPTION
## Summary
- 实现 #46：`health_regen` 选中后生命条分段整体闪绿（约 0.3s）
- 血条上方显示绿色「+1」浮字，0.5s 上移并淡出
- 复用 `EventBus.on_pick_feedback`，与 `max_health_up` 扫光反馈并列，不打断战斗

## Test plan
- [ ] 升级时选择「生命恢复」，确认全段血条闪绿
- [ ] 确认血条上方出现「+1」并淡出
- [ ] 确认选能力后仍可立即移动/格挡
- [ ] `godot --headless --path . --quit` 通过

Closes #46