### PR TITLE
fix: 重新开始游戏时重置所有能力状态

### DIFF
--- a/ability/ability_manager.gd
+++ b/ability/ability_manager.gd
@@ -161,6 +161,17 @@ func get_player() -> Node:
 	return _player
 
 
+## 重新开始一局时清空已获得能力与升级候选状态（Autoload 不随场景重载而重置）
+func reset_for_new_run() -> void:
+	_instances.clear()
+	_pending_level_up_selections = 0
+	_selection_in_progress = false
+	_player = null
+	_rebuild_pipeline()
+	abilities_updated.emit()
+	print("[AbilityManager] 已重置本局能力状态")
+
+
 # ─── 内部：管线重建 ────────────────────────────────────────────────────────────
 
 func _rebuild_pipeline() -> void:

--- a/game_over/game_over_ui.gd
+++ b/game_over/game_over_ui.gd
@@ -60,4 +60,5 @@ func _input(event: InputEvent) -> void:
 			should_restart = true
 	
 	if should_restart:
+		AbilityManager.reset_for_new_run()
 		get_tree().reload_current_scene()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

游戏结束后点击屏幕重新开始时，已通过 `AbilityManager`（Autoload）获得的能力（例如 `max_health_up` 的血量上限加成）仍然保留。

`reload_current_scene()` 只会重载 `main.tscn` 内的节点，不会重置 Autoload 单例中的 `_instances` 与修饰器管线。

## 修复

- 在 `AbilityManager` 新增 `reset_for_new_run()`：清空已获得能力、待处理升级候选、玩家引用，并重建空管线，发出 `abilities_updated`。
- 在 `game_over_ui.gd` 重新开始前调用上述重置。

## 验证

- `godot --headless --import` 通过

## 影响范围

重新开始后，**所有**能力（属性管线加成与行为型实例）均会清零；经验、血量、B 弹等随主场景重载的组件仍会各自在 `_ready` 中恢复初始状态。
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://w1777342061-oij242592.slack.com/archives/C0B08H7RTUJ/p1779266933100229?thread_ts=1779266933.100229&cid=C0B08H7RTUJ)

<div><a href="https://cursor.com/agents/bc-6c3cfc76-4eb8-57a5-81cc-189471409207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c3cfc76-4eb8-57a5-81cc-189471409207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

